### PR TITLE
[BUGFIX] Correct sorting on foreign side of relations 

### DIFF
--- a/Classes/DataHandling/Operation/AbstractRecordOperation.php
+++ b/Classes/DataHandling/Operation/AbstractRecordOperation.php
@@ -192,7 +192,7 @@ abstract class AbstractRecordOperation
 
         if (!empty($this->dataHandler->errorLog)) {
             throw new DataHandlerErrorException(
-                'Error occured during the data handling: ' . implode(', ', $this->dataHandler->errorLog)
+                'Error occurred during the data handling: ' . implode(', ', $this->dataHandler->errorLog)
                 . ' Datamap: ' . json_encode($this->dataHandler->datamap)
                 . ' Cmdmap: ' . json_encode($this->dataHandler->cmdmap),
                 1634296039450

--- a/Classes/DataHandling/Operation/Event/Handler/ForeignRelationSortingEventHandler.php
+++ b/Classes/DataHandling/Operation/Event/Handler/ForeignRelationSortingEventHandler.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pixelant\Interest\DataHandling\Operation\Event\Handler;
+
+use Pixelant\Interest\DataHandling\DataHandler;
+use Pixelant\Interest\DataHandling\Operation\Event\AfterRecordOperationEvent;
+use Pixelant\Interest\DataHandling\Operation\Event\AfterRecordOperationEventHandlerInterface;
+use Pixelant\Interest\DataHandling\Operation\Exception\DataHandlerErrorException;
+use Pixelant\Interest\Domain\Repository\RemoteIdMappingRepository;
+use Pixelant\Interest\Utility\DatabaseUtility;
+use Pixelant\Interest\Utility\TcaUtility;
+use TYPO3\CMS\Core\Database\RelationHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Checks MM relations from a recently created record and makes sure the record has the correct order in the list of
+ * items on the remote side.
+ *
+ * @see RelationSortingAsMetaDataEventHandler
+ */
+class ForeignRelationSortingEventHandler implements AfterRecordOperationEventHandlerInterface
+{
+    protected ?RemoteIdMappingRepository $mappingRepository = null;
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(AfterRecordOperationEvent $event): void
+    {
+        $this->event = $event;
+
+        $this->mappingRepository = GeneralUtility::makeInstance(RemoteIdMappingRepository::class);
+
+        $data = [];
+        foreach ($this->getMmFieldConfigurations() as $fieldName => $fieldConfiguration) {
+            $relationIds = $event->getRecordOperation()->getData()[$fieldName] ?? [];
+
+            if (empty($relationIds)) {
+                continue;
+            }
+
+            if (!is_array($relationIds)) {
+                $relationIds = explode(',', $relationIds);
+            }
+
+            $foreignTable = $fieldConfiguration['foreign_table'] ?? null;
+            if (
+                $fieldConfiguration['type'] === 'group'
+                && $fieldConfiguration['allowed'] !== '*'
+                && strpos($fieldConfiguration['allowed'], ',') === false
+            ) {
+                $foreignTable = $fieldConfiguration['allowed'];
+            }
+
+            foreach ($relationIds as $relationId) {
+                if ($fieldConfiguration['type'] === 'group' && $foreignTable === null) {
+                    $parts = explode('_', $relationId);
+                    $relationId = array_pop($parts);
+                    $foreignTable = implode('_', $parts);
+                }
+
+                $data = array_merge_recursive(
+                    $data,
+                    $this->orderOnForeignSideOfRelation($foreignTable, (int)$relationId)
+                );
+            }
+        }
+
+        if (count($data) > 0) {
+            $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+            $dataHandler->start($data, []);
+            $dataHandler->process_datamap();
+
+            if (!empty($this->dataHandler->errorLog)) {
+                throw new DataHandlerErrorException(
+                    'Error occurred during foreign-side relation ordering in remote ID based on relations'
+                    . ' from remote ID "' . $event->getRecordOperation()->getRemoteId() . '": '
+                    . implode(', ', $this->dataHandler->errorLog)
+                    . ' Datamap: ' . json_encode($this->dataHandler->datamap),
+                    1641480842077
+                );
+            }
+        }
+    }
+
+    /**
+     * Returns the names of fields with an MM relation table.
+     *
+     * @param string $tableName
+     * @return array
+     */
+    protected function getMmFieldConfigurations(): array
+    {
+        $recordOperation = $this->event->getRecordOperation();
+
+        $persistedRecordData = DatabaseUtility::getRecord(
+            $recordOperation->getTable(),
+            $recordOperation->getUid()
+        );
+
+        $fieldConfigurations = [];
+        foreach (array_keys($GLOBALS['TCA'][$recordOperation->getTable()]['columns']) as $fieldName) {
+            $fieldConfiguration = TcaUtility::getTcaFieldConfigurationAndRespectColumnsOverrides(
+                $recordOperation->getTable(),
+                $fieldName,
+                $persistedRecordData
+            );
+
+            if (!empty($fieldConfiguration['MM'] ?? '')) {
+                $fieldConfigurations[$fieldName] = $fieldConfiguration;
+            }
+        }
+
+        return $fieldConfigurations;
+    }
+
+    protected function orderOnForeignSideOfRelation(string $table, int $relationId): array
+    {
+        $foreignRemoteId = $this->mappingRepository->getRemoteId($table, $relationId);
+        $localRemoteId = $this->event->getRecordOperation()->getRemoteId();
+
+        if ($foreignRemoteId === false) {
+            return [];
+        }
+
+        $orderingIntents = $this->mappingRepository->getMetaDataValue(
+            $foreignRemoteId,
+            RelationSortingAsMetaDataEventHandler::class
+        ) ?? [];
+
+        foreach ($orderingIntents as $fieldName => $orderingIntent) {
+            if (in_array($localRemoteId, $orderingIntent)) {
+                $fieldConfiguration = TcaUtility::getTcaFieldConfigurationAndRespectColumnsOverrides(
+                    $table,
+                    $fieldName,
+                    DatabaseUtility::getRecord($table, $relationId)
+                );
+
+                /** @var RelationHandler $relationHandler */
+                $relationHandler = GeneralUtility::makeInstance(RelationHandler::class);
+
+                $relationHandler->start(
+                    '',
+                    $fieldConfiguration['type'] === 'group'
+                        ? $fieldConfiguration['allowed']
+                        : $fieldConfiguration['foreign_table'],
+                    $fieldConfiguration['MM'],
+                    $relationId,
+                    $table,
+                    $fieldConfiguration
+                );
+
+                $relations = $relationHandler->getFromDB();
+
+                $prefixTable = (
+                    $fieldConfiguration['type'] === 'group'
+                    && (
+                        $fieldConfiguration['allowed'] === '*'
+                        || strpos($fieldConfiguration['foreign_table'], ',') !== false
+                    )
+                );
+
+                $flattenedRelations = [];
+                foreach ($relations as $relationTable => $relation) {
+                    if (!$prefixTable) {
+                        $flattenedRelations = array_column($relation, 'uid');
+
+                        break;
+                    }
+
+                    $flattenedRelations = array_map(
+                        function (int $item) use ($relationTable) {
+                            return $relationTable . '_' . $item;
+                        },
+                        array_column($relation, 'uid')
+                    );
+                }
+
+                $orderedUids = [];
+                foreach ($orderingIntent as $remoteIdToOrder) {
+                    $uid = $this->mappingRepository->get($remoteIdToOrder);
+
+                    if ($uid === 0) {
+                        continue;
+                    }
+
+                    if (!$prefixTable) {
+                        $orderedUids[] = $uid;
+
+                        continue;
+                    }
+
+                    $orderedUids[] = $this->mappingRepository->table($remoteIdToOrder) . '_' . $uid;
+                }
+
+                $orderedRelations = array_merge(
+                    $orderedUids,
+                    array_diff($orderedUids, $flattenedRelations)
+                );
+
+                // Save some time by not updating correctly ordered arrays.
+                if ($orderedUids === array_slice($orderedRelations, 0, count($orderedUids))) {
+                    return [];
+                }
+
+                return [
+                    $table => [
+                        (string)$relationId => [
+                            $fieldName => $orderedRelations,
+                        ],
+                    ],
+                ];
+            }
+        }
+
+        return [];
+    }
+}

--- a/Classes/DataHandling/Operation/Event/Handler/RelationSortingAsMetaDataEventHandler.php
+++ b/Classes/DataHandling/Operation/Event/Handler/RelationSortingAsMetaDataEventHandler.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pixelant\Interest\DataHandling\Operation\Event\Handler;
+
+use Pixelant\Interest\DataHandling\Operation\Event\BeforeRecordOperationEvent;
+use Pixelant\Interest\DataHandling\Operation\Event\BeforeRecordOperationEventHandlerInterface;
+use Pixelant\Interest\Domain\Repository\RemoteIdMappingRepository;
+use Pixelant\Interest\Utility\TcaUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Saves metadata information about sorting order for all MM-relation fields with >1 items. This information is used
+ * when persisting the foreign side of the relation to ensure the ordering is correct, even if the foreign relations are
+ * created one-by-one.
+ *
+ * @see ForeignRelationSortingEventHandler
+ */
+class RelationSortingAsMetaDataEventHandler implements BeforeRecordOperationEventHandlerInterface
+{
+    /**
+     * @var BeforeRecordOperationEvent
+     */
+    protected BeforeRecordOperationEvent $event;
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(BeforeRecordOperationEvent $event): void
+    {
+        $this->event = $event;
+
+        $mmFieldConfigurations = $this->getSortedMmRelationFieldConfigurations();
+
+        if (count($mmFieldConfigurations) === 0) {
+            return;
+        }
+
+        $this->addSortingIntentToMetaData($mmFieldConfigurations);
+    }
+
+    /**
+     * Returns the TCA configurations (with overrides) for the table's MM fields.
+     *
+     * @return array
+     */
+    protected function getSortedMmRelationFieldConfigurations(): array
+    {
+        $recordOperation = $this->event->getRecordOperation();
+
+        if (!isset($GLOBALS['TCA'][$recordOperation->getTable()]['columns'])) {
+            return [];
+        }
+
+        $fieldConfigurations = [];
+        foreach (array_keys($GLOBALS['TCA'][$recordOperation->getTable()]['columns']) as $fieldName) {
+            $fieldConfiguration = TcaUtility::getTcaFieldConfigurationAndRespectColumnsOverrides(
+                $recordOperation->getTable(),
+                $fieldName,
+                $recordOperation->getData(),
+                $recordOperation->getRemoteId()
+            );
+
+            if (
+                !empty($fieldConfiguration['MM'] ?? '')
+                && (!isset($fieldConfiguration['maxitems']) || $fieldConfiguration['maxitems'] > 1)
+            ) {
+                $fieldConfigurations[$fieldName] = $fieldConfiguration;
+            }
+        }
+
+        return $fieldConfigurations;
+    }
+
+    /**
+     * Persists the sorting intent (ordered remoteIds) to meta data.
+     *
+     * @param array $fieldConfigurations
+     */
+    protected function addSortingIntentToMetaData(array $fieldConfigurations)
+    {
+        $recordOperation = $this->event->getRecordOperation();
+
+        $sortingIntents = [];
+        foreach ($fieldConfigurations as $fieldName => $configuration) {
+            $sortingIntent = $recordOperation->getData()[$fieldName] ?? [];
+
+            if (empty($sortingIntent)) {
+                continue;
+            }
+
+            if (!is_array($sortingIntent)) {
+                $sortingIntent = explode(',', $sortingIntent);
+            }
+
+            $sortingIntents[$fieldName] = $sortingIntent;
+        }
+
+        $mappingRepository = GeneralUtility::makeInstance(RemoteIdMappingRepository::class);
+
+        $mappingRepository->setMetaDataValue(
+            $recordOperation->getRemoteId(),
+            RelationSortingAsMetaDataEventHandler::class,
+            $sortingIntents
+        );
+    }
+}

--- a/Classes/DataHandling/Operation/UpdateRecordOperation.php
+++ b/Classes/DataHandling/Operation/UpdateRecordOperation.php
@@ -5,13 +5,9 @@ declare(strict_types=1);
 
 namespace Pixelant\Interest\DataHandling\Operation;
 
-use Pixelant\Interest\DataHandling\Operation\Exception\IdentityConflictException;
 use Pixelant\Interest\DataHandling\Operation\Exception\NotFoundException;
 use Pixelant\Interest\Domain\Repository\RemoteIdMappingRepository;
-use Pixelant\Interest\Handler\Exception\ConflictException;
-use Pixelant\Interest\Utility\RelationUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\StringUtility;
 
 /**
  * Performs an update operation on a record.

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -38,8 +38,18 @@ defined('TYPO3_MODE') or die('Access denied.');
     );
 
     \Pixelant\Interest\Utility\CompatibilityUtility::registerEventHandlerAsSignalSlot(
+        \Pixelant\Interest\DataHandling\Operation\Event\BeforeRecordOperationEvent::class,
+        \Pixelant\Interest\DataHandling\Operation\Event\Handler\RelationSortingAsMetaDataEventHandler::class
+    );
+
+    \Pixelant\Interest\Utility\CompatibilityUtility::registerEventHandlerAsSignalSlot(
         \Pixelant\Interest\DataHandling\Operation\Event\AfterRecordOperationEvent::class,
         \Pixelant\Interest\DataHandling\Operation\Event\Handler\ProcessDeferredRecordOperationsEventHandler::class
+    );
+
+    \Pixelant\Interest\Utility\CompatibilityUtility::registerEventHandlerAsSignalSlot(
+        \Pixelant\Interest\DataHandling\Operation\Event\AfterRecordOperationEvent::class,
+        \Pixelant\Interest\DataHandling\Operation\Event\Handler\ForeignRelationSortingEventHandler::class
     );
 
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Core\Console\CommandRequestHandler::class] = [


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description

Records with MM relations now store information about correct relation sorting in the mapping table's meta data.

This is used when a foreign record is a pending relation. When the foreign relation is inserted the local relation field is updated with the correct order as well.

This is also used when a foreign relation is updated, in case the relation is missing or the order is wrong on the other side.

Also allows adding metadata before the remote ID is mapped. Metadata is stored in a temporary static property `RemoteIdMappingRepository::$unmappedMetaDataEntries`
