### PR TITLE
[BUGFIX] Update relation count on parent of inline relation record

### DIFF
--- a/Classes/DataHandling/Operation/AbstractRecordOperation.php
+++ b/Classes/DataHandling/Operation/AbstractRecordOperation.php
@@ -133,13 +133,10 @@ abstract class AbstractRecordOperation
         $this->data = $data;
         $this->metaData = $metaData ?? [];
 
-        /** @noinspection PhpFieldAssignmentTypeMismatchInspection */
         $this->configurationProvider = GeneralUtility::makeInstance(ConfigurationProvider::class);
 
-        /** @noinspection PhpFieldAssignmentTypeMismatchInspection */
         $this->mappingRepository = GeneralUtility::makeInstance(RemoteIdMappingRepository::class);
 
-        /** @noinspection PhpFieldAssignmentTypeMismatchInspection */
         $this->pendingRelationsRepository = GeneralUtility::makeInstance(PendingRelationsRepository::class);
 
         $this->language = $this->resolveLanguage((string)$language);
@@ -169,7 +166,6 @@ abstract class AbstractRecordOperation
 
         $this->prepareRelations();
 
-        /** @noinspection PhpFieldAssignmentTypeMismatchInspection */
         $this->dataHandler = GeneralUtility::makeInstance(DataHandler::class);
         $this->dataHandler->start([], []);
 

--- a/Classes/DataHandling/Operation/Event/Handler/UpdateCountOnForeignSideOfInlineRecordEventHandler.php
+++ b/Classes/DataHandling/Operation/Event/Handler/UpdateCountOnForeignSideOfInlineRecordEventHandler.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace Pixelant\Interest\DataHandling\Operation\Event\Handler;
+
+use Pixelant\Interest\DataHandling\Operation\DeleteRecordOperation;
+use Pixelant\Interest\DataHandling\Operation\Event\BeforeRecordOperationEvent;
+use Pixelant\Interest\DataHandling\Operation\Event\BeforeRecordOperationEventHandlerInterface;
+use Pixelant\Interest\Utility\DatabaseUtility;
+use Pixelant\Interest\Utility\RelationUtility;
+use Pixelant\Interest\Utility\TcaUtility;
+use TYPO3\CMS\Core\Database\RelationHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Updates the inline relation record count stored in the parent record field before we delete one of the relations.
+ *
+ * When a parent record has an inline (IRRE) relation to a child record, TYPO3 stores the relation count (the number of
+ * relations) in the parent record field used for the relation. Child relation records could e.g. be sys_file_reference
+ * records.
+ *
+ * If we delete one of these records, the count on the parent record won't be updated. This is because TYPO3's
+ * DataHandler expects the delete operation to come through a modification of the parent record.
+ *
+ * If the record count is higher than the actual number of relations, Extbase will trigger an exception.
+ *
+ * Given a DeleteRecordOperation, this EventHandler iterates through all tables and fields that potentially could have
+ * a parent relationship to the record being deleted. When it finds a parent record, it will count the number of child
+ * relations, subtract 1 for the record being deleted, and update the count field in the parent record. The EventHandler
+ * also takes record-type-related changes to a field's configuration into account.
+ */
+class UpdateCountOnForeignSideOfInlineRecordEventHandler implements BeforeRecordOperationEventHandlerInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(BeforeRecordOperationEvent $event): void
+    {
+        if (!($event->getRecordOperation() instanceof DeleteRecordOperation)) {
+            return;
+        }
+
+        RelationUtility::updateParentRecordInlineFieldRelationCount(
+            $event->getRecordOperation()->getTable(),
+            $event->getRecordOperation()->getUid(),
+            -1
+        );
+    }
+}

--- a/Classes/DataHandling/Operation/Event/Handler/UpdateCountOnForeignSideOfInlineRecordEventHandler.php
+++ b/Classes/DataHandling/Operation/Event/Handler/UpdateCountOnForeignSideOfInlineRecordEventHandler.php
@@ -6,11 +6,7 @@ namespace Pixelant\Interest\DataHandling\Operation\Event\Handler;
 use Pixelant\Interest\DataHandling\Operation\DeleteRecordOperation;
 use Pixelant\Interest\DataHandling\Operation\Event\BeforeRecordOperationEvent;
 use Pixelant\Interest\DataHandling\Operation\Event\BeforeRecordOperationEventHandlerInterface;
-use Pixelant\Interest\Utility\DatabaseUtility;
 use Pixelant\Interest\Utility\RelationUtility;
-use Pixelant\Interest\Utility\TcaUtility;
-use TYPO3\CMS\Core\Database\RelationHandler;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Updates the inline relation record count stored in the parent record field before we delete one of the relations.

--- a/Classes/Utility/RelationUtility.php
+++ b/Classes/Utility/RelationUtility.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Pixelant\Interest\Utility;
 
+use Pixelant\Interest\DataHandling\Operation\Event\Handler\UpdateCountOnForeignSideOfInlineRecordEventHandler;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\RelationHandler;
 use Pixelant\Interest\DataHandling\DataHandler;
@@ -51,5 +52,192 @@ class RelationUtility
 
         $dataHandler->datamap[$pendingRelation['table']][$pendingRelation['record_uid']][$pendingRelation['field']]
             = implode(',', array_unique(array_merge($existingRelations, [$foreignUid])));
+    }
+
+    /**
+     * Returns the relations from a record field.
+     *
+     * @param string $table The table name
+     * @param int $uid The record UID
+     * @param string $field The field name
+     * @param array $rowWithRecordType Real or simulated record data. Must at least contain type value.
+     * @return array
+     */
+    public static function getRelationsFromField(
+        string $table,
+        int $uid,
+        string $field,
+        array $rowWithRecordType = []
+    ): array
+    {
+        return self::getRelationsFromFieldConfiguration(
+            $table,
+            $uid,
+            TcaUtility::getTcaFieldConfigurationAndRespectColumnsOverrides(
+                $table,
+                $field,
+                $rowWithRecordType
+            )
+        );
+    }
+
+    /**
+     * Returns the relations from a record field based on the field configuration.
+     *
+     * @param string $table
+     * @param int $uid
+     * @param array $fieldConfig
+     * @return array
+     */
+    public static function getRelationsFromFieldConfiguration(
+        string $table,
+        int $uid,
+        array $fieldConfig
+    ): array
+    {
+        $relationHandler = GeneralUtility::makeInstance(RelationHandler::class);
+
+        $relationHandler->start(
+            '',
+            $fieldConfig['foreign_table'],
+            '',
+            $uid,
+            $table,
+            $fieldConfig
+        );
+
+        return $relationHandler->tableArray;
+    }
+
+    /**
+     * Returns the UIDs of records that share the same parent. Including the record $localUid itself.
+     *
+     * @param string $localTable
+     * @param int $localUid
+     * @param string $foreignTable
+     * @param string $foreignField
+     * @param int|string|null $recordType
+     * @return array[] One key and one value. Key is the foreign table record UID and value is an array of relations.
+     */
+    public static function getSiblingRelationsOfForeignParent(
+        string $localTable,
+        int $localUid,
+        string $foreignTable,
+        string $foreignField,
+        $recordType = null
+    ): array
+    {
+        $rowWithTypeField = [];
+
+        $typeField = TcaUtility::getTypeFieldForTable($foreignTable);
+
+        if ($typeField !== null || $recordType === null) {
+            $rowWithTypeField = [$typeField => $recordType];
+        }
+
+        $parentTableFieldConfig = TcaUtility::getTcaFieldConfigurationAndRespectColumnsOverrides(
+            $foreignTable,
+            $foreignField,
+            $rowWithTypeField
+        );
+
+        /** @var RelationHandler $relationHandler */
+        $relationHandler = GeneralUtility::makeInstance(RelationHandler::class);
+
+        $relationHandler->setFetchAllFields(true);
+
+        $relationHandler->start(
+            $localUid,
+            $localTable,
+            $parentTableFieldConfig['MM'] ?? '',
+            0,
+            $foreignTable,
+            $parentTableFieldConfig
+        );
+
+        $relationHandler->getFromDB();
+
+        $result = $relationHandler->results[$localTable][$localUid];
+
+        if ($result[$parentTableFieldConfig['foreign_table_field']] !== $foreignTable) {
+            return [];
+        }
+
+        $relations = self::getRelationsFromFieldConfiguration(
+            $foreignTable,
+            $result[$parentTableFieldConfig['foreign_field']],
+            $parentTableFieldConfig
+        );
+
+        if (!in_array($localUid, $relations[$localTable])) {
+            return [];
+        }
+
+        return [$result[$parentTableFieldConfig['foreign_field']] => $relations];
+    }
+
+    /**
+     * Update the relation count for inline (IRRE) fields in parent records to this record.
+     *
+     * @see UpdateCountOnForeignSideOfInlineRecordEventHandler
+     *
+     * @param string $localTable
+     * @param int $localUid
+     * @param int $countModifier Number to add or subtract from the count.
+     * @return void
+     */
+    public static function updateParentRecordInlineFieldRelationCount(
+        string $localTable,
+        int $localUid,
+        int $countModifier = 0
+    )
+    {
+        $inlineRelations = TcaUtility::getInlineRelationsToTable($localTable);
+
+        if (count($inlineRelations) === 0) {
+            return;
+        }
+
+        foreach ($inlineRelations as $foreignTable => $fields) {
+            foreach ($fields as $foreignFieldName => $recordTypes) {
+                foreach ($recordTypes as $recordType) {
+                    $result = self::getSiblingRelationsOfForeignParent(
+                        $localTable,
+                        $localUid,
+                        $foreignTable,
+                        $foreignFieldName,
+                        $recordType
+                    );
+
+                    $foreignUid = array_key_first($result);
+                    $relations = $result[$foreignUid];
+
+                    if (count($relations) === 0) {
+                        continue;
+                    }
+
+                    $count = array_reduce(
+                        $relations,
+                        function (int $carry, array $records) {
+                            return $carry + count($records);
+                        },
+                        0
+                    );
+
+                    $queryBuilder = DatabaseUtility::getQueryBuilderForTable($foreignTable);
+
+                    $queryBuilder
+                        ->update($foreignTable)
+                        ->set($foreignFieldName, $count + $countModifier)
+                        ->where(
+                            $queryBuilder->expr()->eq(
+                                'uid',
+                                $foreignUid
+                            )
+                        )
+                        ->execute();
+                }
+            }
+        }
     }
 }

--- a/Classes/Utility/TcaUtility.php
+++ b/Classes/Utility/TcaUtility.php
@@ -8,11 +8,24 @@ namespace Pixelant\Interest\Utility;
 
 use Pixelant\Interest\Domain\Repository\RemoteIdMappingRepository;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class TcaUtility
 {
+    /**
+     * [
+     *     'tableName' => [
+     *         ''
+     *     ],
+     * ]
+     *
+     * @var array|null
+     * @see TcaUtility::getInlineRelationsToTable()
+     */
+    protected static ?array $inlineRelationsToTablesCache = null;
+
     /**
      * Returns true if the table is localizable.
      *
@@ -107,5 +120,76 @@ class TcaUtility
         }
 
         return $tcaFieldConf;
+    }
+
+    /**
+     * Get a list of the tables and fields where $tableName is used as inline records (type=inline in the TCA).
+     *
+     * A returned array might look like:
+     *
+     * [
+     *     'tablename1' => ['field1', 'field2'],
+     *     'tablename2' => ['field2'],
+     * ]
+     *
+     * @param string $tableName
+     * @return array
+     */
+    public static function getInlineRelationsToTable(string $tableName): array
+    {
+        if (self::$inlineRelationsToTablesCache === null) {
+            $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
+
+            $cacheName = CompatibilityUtility::typo3VersionIsLessThan('10') ? 'cache_hash' : 'hash';
+
+            $cacheHash = md5(self::class . '_inlineRelationsToTables');
+
+            $cache = $cacheManager->getCache($cacheName);
+
+            self::$inlineRelationsToTablesCache = $cache->get($cacheHash) ?: null;
+
+            if (self::$inlineRelationsToTablesCache === null || !is_array(self::$inlineRelationsToTablesCache)) {
+                self::$inlineRelationsToTablesCache = [];
+
+                foreach ($GLOBALS['TCA'] as $table => $tableConfig) {
+                    $recordTypeKeys = array_keys($tableConfig['types']);
+
+                    foreach (array_keys($tableConfig['columns']) as $fieldName) {
+                        $typeFieldName = static::getTypeFieldForTable($table);
+
+                        foreach ($recordTypeKeys as $recordTypeKey) {
+                            $row = $typeFieldName === null ? [] : [$typeFieldName => $recordTypeKey];
+
+                            $fieldConfig = static::getTcaFieldConfigurationAndRespectColumnsOverrides(
+                                $table,
+                                $fieldName,
+                                $row
+                            );
+
+                            if ($fieldConfig['type'] === 'inline') {
+                                self::$inlineRelationsToTablesCache[
+                                    $fieldConfig['foreign_table']
+                                ][$table][$fieldName][] = $recordTypeKey;
+                            }
+                        }
+                    }
+                }
+
+                $cache->set($cacheHash, self::$inlineRelationsToTablesCache);
+            }
+        }
+
+        return self::$inlineRelationsToTablesCache[$tableName] ?? [];
+    }
+
+    /**
+     * Returns the name of the record type field or null if there is none.
+     *
+     * @param string $table
+     * @return string|null
+     */
+    public static function getTypeFieldForTable(string $table): ?string
+    {
+        return $GLOBALS['TCA'][$table]['ctrl']['type'] ?? null;
     }
 }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -25,8 +25,26 @@ services:
         identifier: deferSysFileReferenceRecordOperation
         event: Pixelant\Interest\DataHandling\Operation\Event\BeforeRecordOperationEvent
 
-  \Pixelant\Interest\DataHandling\Operation\Event\Handler\ProcessDeferredRecordOperationsEventHandler:
+  Pixelant\Interest\DataHandling\Operation\Event\Handler\RelationSortingAsMetaDataEventHandler:
+    tags:
+      - name: event.listener
+        identifier: relationSortingAsMetaData
+        event: Pixelant\Interest\DataHandling\Operation\Event\BeforeRecordOperationEvent
+
+  Pixelant\Interest\DataHandling\Operation\Event\Handler\UpdateCountOnForeignSideOfInlineRecordEventHandler:
+    tags:
+      - name: event.listener
+        identifier: updateCountOnForeignSideOfInlineRecord
+        event: Pixelant\Interest\DataHandling\Operation\Event\BeforeRecordOperationEvent
+
+  Pixelant\Interest\DataHandling\Operation\Event\Handler\ProcessDeferredRecordOperationsEventHandler:
     tags:
       - name: event.listener
         identifier: processDeferredRecordOperations
+        event: Pixelant\Interest\DataHandling\Operation\Event\AfterRecordOperationEvent
+
+  Pixelant\Interest\DataHandling\Operation\Event\Handler\ForeignRelationSortingEventHandler:
+    tags:
+      - name: event.listener
+        identifier: foreignRelationSorting
         event: Pixelant\Interest\DataHandling\Operation\Event\AfterRecordOperationEvent

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -43,6 +43,11 @@ defined('TYPO3_MODE') or die('Access denied.');
     );
 
     \Pixelant\Interest\Utility\CompatibilityUtility::registerEventHandlerAsSignalSlot(
+        \Pixelant\Interest\DataHandling\Operation\Event\BeforeRecordOperationEvent::class,
+        \Pixelant\Interest\DataHandling\Operation\Event\Handler\UpdateCountOnForeignSideOfInlineRecordEventHandler::class
+    );
+
+    \Pixelant\Interest\Utility\CompatibilityUtility::registerEventHandlerAsSignalSlot(
         \Pixelant\Interest\DataHandling\Operation\Event\AfterRecordOperationEvent::class,
         \Pixelant\Interest\DataHandling\Operation\Event\Handler\ProcessDeferredRecordOperationsEventHandler::class
     );


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description
When a parent record has an inline (IRRE) relation to a child record, TYPO3 stores the relation count (the number of relations) in the parent record field used for the relation. Child relation records could e.g. be sys_file_reference records.

If we delete one of these records, the count on the parent record won't be updated. This is because TYPO3's DataHandler expects the delete operation to come through a modification of the parent record.

If the record count is higher than the actual number of relations, Extbase will trigger an exception.

Given a DeleteRecordOperation, this commit introduces an EventHandler that iterates through all tables and fields that potentially could have a parent relationship to the record being deleted. When it finds a parent record, it will count the number of child relations, subtract 1 for the record being deleted, and update the count field in the parent record. The EventHandler also takes record-type-related changes to a field's configuration into account.
