### PR TITLE
[BUGFIX] Ignore empty remote IDs on pending relations

### DIFF
--- a/Classes/DataHandling/Operation/AbstractRecordOperation.php
+++ b/Classes/DataHandling/Operation/AbstractRecordOperation.php
@@ -460,6 +460,8 @@ abstract class AbstractRecordOperation
 
             if (!is_array($fieldValue)) {
                 $fieldValue = GeneralUtility::trimExplode(',', $fieldValue, true);
+            } else {
+                $fieldValue = array_filter($fieldValue);
             }
 
             $this->detectPendingRelations(

--- a/Classes/Domain/Repository/PendingRelationsRepository.php
+++ b/Classes/Domain/Repository/PendingRelationsRepository.php
@@ -56,19 +56,35 @@ class PendingRelationsRepository extends AbstractRepository
     {
         $this->removeLocal($table, $field, $uid);
 
-        foreach ($remoteIds as $remoteId) {
-            $queryBuilder = $this->getQueryBuilder();
+        $remoteIds = array_filter($remoteIds);
 
-            $queryBuilder
-                ->insert(self::TABLE_NAME)
-                ->values([
-                    'remote_id' => $remoteId,
-                    'table' => $table,
-                    'field' => $field,
-                    'record_uid' => $uid,
-                ])
-                ->execute();
+        foreach ($remoteIds as $remoteId) {
+            $this->setSingle($table, $field, $uid, $remoteId);
         }
+    }
+
+    /**
+     * Sets a relation for $field in record $uid in $table. Does NOT remove any existing records.
+     *
+     * @param string $table
+     * @param string $field
+     * @param int $uid
+     * @param string $remoteId
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function setSingle(string $table, string $field, int $uid, string $remoteId)
+    {
+        $queryBuilder = $this->getQueryBuilder();
+
+        $queryBuilder
+            ->insert(self::TABLE_NAME)
+            ->values([
+                'remote_id' => $remoteId,
+                'table' => $table,
+                'field' => $field,
+                'record_uid' => $uid,
+            ])
+            ->execute();
     }
 
     /**

--- a/Classes/Updates/AbstractUpdateWizard.php
+++ b/Classes/Updates/AbstractUpdateWizard.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pixelant\Interest\Updates;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+
+abstract class AbstractUpdateWizard implements UpgradeWizardInterface
+{
+    public const IDENTIFIER = '';
+
+    public const TITLE = '';
+
+    public const DESCRIPTION = '';
+
+    /**
+     * @inheritDoc
+     */
+    public function getIdentifier(): string
+    {
+        return self::IDENTIFIER;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTitle(): string
+    {
+        return self::TITLE;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDescription(): string
+    {
+        return self::DESCRIPTION;
+    }
+
+    /**
+     * @param string $table
+     * @return QueryBuilder
+     */
+    protected function getQueryBuilderForTable(string $table): QueryBuilder
+    {
+        return GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable($table);
+    }
+}

--- a/Classes/Updates/RemovePendingRelationsWithEmptyRemoteIdUpdateWizard.php
+++ b/Classes/Updates/RemovePendingRelationsWithEmptyRemoteIdUpdateWizard.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pixelant\Interest\Updates;
+
+use Pixelant\Interest\Domain\Repository\PendingRelationsRepository;
+use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Install\Updates\ChattyInterface;
+
+class RemovePendingRelationsWithEmptyRemoteIdUpdateWizard extends AbstractUpdateWizard implements ChattyInterface
+{
+    public const IDENTIFIER = 'interest_removePendingRelationsWithEmptyRemoteId';
+
+    public const TITLE = 'Remove Invalid Pending Relations';
+
+    public const DESCRIPTION = 'Removes pending relation records with empty remote IDs.';
+
+    protected ?OutputInterface $output = null;
+
+    /**
+     * @inheritDoc
+     */
+    public function setOutput(OutputInterface $output): void
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function executeUpdate(): bool
+    {
+        $queryBuilder = $this->getQueryBuilderForTable(PendingRelationsRepository::TABLE_NAME);
+
+        $deletedCount = $queryBuilder
+            ->delete(PendingRelationsRepository::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->eq('remote_id', $queryBuilder->quote(''))
+            )
+            ->execute();
+
+        if ($this->output !== null) {
+            $this->output->writeln('Deleted ' . $deletedCount . ' pending relations with empty remote ID.');
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateNecessary(): bool
+    {
+        $queryBuilder = $this->getQueryBuilderForTable(PendingRelationsRepository::TABLE_NAME);
+
+        return (bool)$queryBuilder
+            ->count('*')
+            ->from(PendingRelationsRepository::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->eq('remote_id', $queryBuilder->quote(''))
+            )
+            ->execute()
+            ->fetchOne();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPrerequisites(): array
+    {
+        return [];
+    }
+}

--- a/Tests/Unit/Domain/Repository/PendingRelationsRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/PendingRelationsRepositoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pixelant\Interest\Tests\Unit\Domain\Repository;
 
 use Pixelant\Interest\Domain\Repository\PendingRelationsRepository;
+use Pixelant\Interest\Utility\CompatibilityUtility;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -15,9 +16,15 @@ class PendingRelationsRepositoryTest extends UnitTestCase
      */
     public function emptyRemoteIdsAreIgnored(): void
     {
-        $subject = $this->getMockBuilder(PendingRelationsRepository::class)
-            ->onlyMethods(['getQueryBuilder', 'setSingle'])
-            ->getMock();
+        if (CompatibilityUtility::typo3VersionIsLessThan('10')) {
+            $subject = $this->getMockBuilder(PendingRelationsRepository::class)
+                ->setMethods(['getQueryBuilder', 'setSingle'])
+                ->getMock();
+        } else {
+            $subject = $this->getMockBuilder(PendingRelationsRepository::class)
+                ->onlyMethods(['getQueryBuilder', 'setSingle'])
+                ->getMock();
+        }
 
         $subject->method('getQueryBuilder')->willReturn(
             $this->createMock(QueryBuilder::class)

--- a/Tests/Unit/Domain/Repository/PendingRelationsRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/PendingRelationsRepositoryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pixelant\Interest\Tests\Unit\Domain\Repository;
+
+use Pixelant\Interest\Domain\Repository\PendingRelationsRepository;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class PendingRelationsRepositoryTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function emptyRemoteIdsAreIgnored(): void
+    {
+        $subject = $this->getMockBuilder(PendingRelationsRepository::class)
+            ->onlyMethods(['getQueryBuilder', 'setSingle'])
+            ->getMock();
+
+        $subject->method('getQueryBuilder')->willReturn(
+            $this->createMock(QueryBuilder::class)
+        );
+
+        $subject
+            ->expects(self::exactly(1))
+            ->method('setSingle')
+            ->with('table1', 'field1', 1, 'remoteId1');
+
+        $subject->set('table1', 'field1', 1, ['remoteId1', '', '']);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -10,6 +10,11 @@ defined('TYPO3_MODE') or die('Access denied.');
         '@import \'EXT:interest/Configuration/TSconfig/User/setup.tsconfig\''
     );
 
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][
+        \Pixelant\Interest\Updates\RemovePendingRelationsWithEmptyRemoteIdUpdateWizard::IDENTIFIER
+    ] = \Pixelant\Interest\Updates\RemovePendingRelationsWithEmptyRemoteIdUpdateWizard::class;
+
+
     if (\Pixelant\Interest\Utility\CompatibilityUtility::typo3VersionIsGreaterThanOrEqualTo('11')) {
         return;
     }
@@ -40,7 +45,6 @@ defined('TYPO3_MODE') or die('Access denied.');
         \TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class
     );
 
-    /** @noinspection PhpUndefinedClassConstantInspection */
     $signalSlotDispatcher->connect(
         \TYPO3\CMS\Core\Resource\ResourceStorage::class,
         \TYPO3\CMS\Core\Resource\ResourceStorage::SIGNAL_PostFileDelete,
@@ -84,7 +88,6 @@ defined('TYPO3_MODE') or die('Access denied.');
         \Pixelant\Interest\DataHandling\Operation\Event\Handler\ForeignRelationSortingEventHandler::class
     );
 
-    /** @noinspection PhpUndefinedClassInspection */
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Core\Console\CommandRequestHandler::class] = [
         'className' => \Pixelant\Interest\Console\OptimizedCommandRequestHandler::class,
     ];


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description

Introduces filters to avoid empty strings in relations. This especially affects pending relations, where the `tx_interest_pending_relations` would be filled with entries with an empty `remote_id` field.

Fixes #60
