### PR TITLE
[BUGFIX] Correct sorting order

### DIFF
--- a/Classes/DataHandling/Operation/Event/Handler/ForeignRelationSortingEventHandler.php
+++ b/Classes/DataHandling/Operation/Event/Handler/ForeignRelationSortingEventHandler.php
@@ -185,7 +185,7 @@ class ForeignRelationSortingEventHandler implements AfterRecordOperationEventHan
                     $foreignTable = implode('_', $parts);
                 }
 
-                $data = array_merge_recursive(
+                ArrayUtility::mergeRecursiveWithOverrule(
                     $data,
                     $this->orderOnForeignSideOfRelation($foreignTable, (int)$relationId)
                 );

--- a/Classes/DataHandling/Operation/Event/Handler/ForeignRelationSortingEventHandler.php
+++ b/Classes/DataHandling/Operation/Event/Handler/ForeignRelationSortingEventHandler.php
@@ -13,6 +13,7 @@ use Pixelant\Interest\Domain\Repository\RemoteIdMappingRepository;
 use Pixelant\Interest\Utility\DatabaseUtility;
 use Pixelant\Interest\Utility\TcaUtility;
 use TYPO3\CMS\Core\Database\RelationHandler;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -78,77 +79,103 @@ class ForeignRelationSortingEventHandler implements AfterRecordOperationEventHan
         return $fieldConfigurations;
     }
 
+    /**
+     * Returns ordered relations for a single field in a record.
+     *
+     * A remote ID can only occur once in one record, and not in multiple fields in the same record. Therefore, this
+     * method will only return an empty array (remote ID is not in a sorted field) or a single-leaf array:
+     *
+     * [
+     *     table => [
+     *         relationId => [
+     *             fieldName => [ uid, ... ]
+     *         ]
+     *     ]
+     * ]
+     *
+     * @param string $table The table of the record.
+     * @param int $relationId The UID of the record.
+     * @return array
+     */
     protected function orderOnForeignSideOfRelation(string $table, int $relationId): array
     {
         $foreignRemoteId = $this->mappingRepository->getRemoteId($table, $relationId);
-        $localRemoteId = $this->event->getRecordOperation()->getRemoteId();
 
         if ($foreignRemoteId === false) {
             return [];
         }
+
+        $localRemoteId = $this->event->getRecordOperation()->getRemoteId();
 
         $orderingIntents = $this->mappingRepository->getMetaDataValue(
             $foreignRemoteId,
             RelationSortingAsMetaDataEventHandler::class
         ) ?? [];
 
+        $fieldName = null;
+        $orderingIntent = null;
+
         foreach ($orderingIntents as $fieldName => $orderingIntent) {
             if (in_array($localRemoteId, $orderingIntent)) {
-                $fieldConfiguration = TcaUtility::getTcaFieldConfigurationAndRespectColumnsOverrides(
-                    $table,
-                    $fieldName,
-                    DatabaseUtility::getRecord($table, $relationId)
-                );
-
-                /** @var RelationHandler $relationHandler */
-                $relationHandler = GeneralUtility::makeInstance(RelationHandler::class);
-
-                $relationHandler->start(
-                    '',
-                    $fieldConfiguration['type'] === 'group'
-                        ? $fieldConfiguration['allowed']
-                        : $fieldConfiguration['foreign_table'],
-                    $fieldConfiguration['MM'],
-                    $relationId,
-                    $table,
-                    $fieldConfiguration
-                );
-
-                $relations = $relationHandler->getFromDB();
-
-                $prefixTable = (
-                    $fieldConfiguration['type'] === 'group'
-                    && (
-                        $fieldConfiguration['allowed'] === '*'
-                        || strpos($fieldConfiguration['foreign_table'], ',') !== false
-                    )
-                );
-
-                $flattenedRelations = $this->flattenRelations($relations, $prefixTable);
-
-                $orderedUids = $this->convertOrderingIntentToOrderedUids($orderingIntent, $prefixTable);
-
-                $orderedRelations = array_merge(
-                    $orderedUids,
-                    array_diff($orderedUids, $flattenedRelations)
-                );
-
-                // Save some time by not updating correctly ordered arrays.
-                if ($orderedUids === array_slice($orderedRelations, 0, count($orderedUids))) {
-                    return [];
-                }
-
-                return [
-                    $table => [
-                        (string)$relationId => [
-                            $fieldName => $orderedRelations,
-                        ],
-                    ],
-                ];
+                break;
             }
         }
 
-        return [];
+        if ($orderingIntent === null) {
+            return [];
+        }
+
+        $fieldConfiguration = TcaUtility::getTcaFieldConfigurationAndRespectColumnsOverrides(
+            $table,
+            $fieldName,
+            DatabaseUtility::getRecord($table, $relationId)
+        );
+
+        /** @var RelationHandler $relationHandler */
+        $relationHandler = GeneralUtility::makeInstance(RelationHandler::class);
+
+        $relationHandler->start(
+            '',
+            $fieldConfiguration['type'] === 'group'
+                ? $fieldConfiguration['allowed']
+                : $fieldConfiguration['foreign_table'],
+            $fieldConfiguration['MM'],
+            $relationId,
+            $table,
+            $fieldConfiguration
+        );
+
+        $relations = $relationHandler->getFromDB();
+
+        $prefixTable = (
+            $fieldConfiguration['type'] === 'group'
+            && (
+                $fieldConfiguration['allowed'] === '*'
+                || strpos($fieldConfiguration['foreign_table'], ',') !== false
+            )
+        );
+
+        $flattenedRelations = $this->flattenRelations($relations, $prefixTable);
+
+        $orderedUids = $this->convertOrderingIntentToOrderedUids($orderingIntent, $prefixTable);
+
+        $orderedRelations = array_merge(
+            $orderedUids,
+            array_diff($orderedUids, $flattenedRelations)
+        );
+
+        // Save some time by not updating correctly ordered arrays.
+        if ($orderedUids === array_slice($orderedRelations, 0, count($orderedUids))) {
+            return [];
+        }
+
+        return [
+            $table => [
+                (string)$relationId => [
+                    $fieldName => $orderedRelations,
+                ],
+            ],
+        ];
     }
 
     /**
@@ -180,7 +207,7 @@ class ForeignRelationSortingEventHandler implements AfterRecordOperationEventHan
 
             foreach ($relationIds as $relationId) {
                 if ($fieldConfiguration['type'] === 'group' && $foreignTable === null) {
-                    $parts = explode('_', $relationId);
+                    $parts = explode('_', (string)$relationId);
                     $relationId = array_pop($parts);
                     $foreignTable = implode('_', $parts);
                 }
@@ -217,9 +244,12 @@ class ForeignRelationSortingEventHandler implements AfterRecordOperationEventHan
     }
 
     /**
-     * @param array $relations
+     * Provided a multidimensional relation array, this method returns a single-dimensional array of UIDs or combined
+     * table_UID strings.
+     *
+     * @param array $relations as [tableName => [ relationRecord => [ ... ], ... ] ].
      * @param bool $prefixTable
-     * @return array|string[]
+     * @return int[]|string[]
      */
     protected function flattenRelations(array $relations, bool $prefixTable): array
     {
@@ -244,6 +274,8 @@ class ForeignRelationSortingEventHandler implements AfterRecordOperationEventHan
     }
 
     /**
+     * Converts a list of remote IDs to an array of UID integers or combines table_UID strings.
+     *
      * @param array $orderingIntent
      * @param bool $prefixTable
      * @return array
@@ -266,6 +298,7 @@ class ForeignRelationSortingEventHandler implements AfterRecordOperationEventHan
 
             $orderedUids[] = $this->mappingRepository->table($remoteIdToOrder) . '_' . $uid;
         }
+
         return $orderedUids;
     }
 }

--- a/Classes/Domain/Repository/AbstractRepository.php
+++ b/Classes/Domain/Repository/AbstractRepository.php
@@ -6,9 +6,10 @@ namespace Pixelant\Interest\Domain\Repository;
 
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-abstract class AbstractRepository
+abstract class AbstractRepository implements SingletonInterface
 {
     public const TABLE_NAME = '';
 

--- a/Tests/Unit/DataHandling/Operation/Event/Handler/ForeignRelationSortingEventHandlerTest.php
+++ b/Tests/Unit/DataHandling/Operation/Event/Handler/ForeignRelationSortingEventHandlerTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pixelant\Interest\Tests\Unit\DataHandling\Operation\Event\Handler;
+
+use Pixelant\Interest\DataHandling\Operation\Event\AfterRecordOperationEvent;
+use Pixelant\Interest\DataHandling\Operation\Event\Handler\ForeignRelationSortingEventHandler;
+use Pixelant\Interest\DataHandling\Operation\UpdateRecordOperation;
+use Pixelant\Interest\Domain\Repository\RemoteIdMappingRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ForeignRelationSortingEventHandlerTest extends UnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resetSingletonInstances = true;
+    }
+
+    /**
+     * @test
+     * @dataProvider invokingGeneratesCorrectSortingDataDataProvider
+     */
+    public function invokingGeneratesCorrectSortingData(
+        array $localRecordData,
+        array $mmFieldConfiguration,
+        array $foreignSideOrderReturns,
+        array $persistDataArgument
+    ) {
+        $mappingRepositoryMock = $this->createMock(RemoteIdMappingRepository::class);
+
+        GeneralUtility::setSingletonInstance(RemoteIdMappingRepository::class, $mappingRepositoryMock);
+
+        $recordOperationMock = $this
+            ->getMockBuilder(UpdateRecordOperation::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['setData', 'getData'])
+            ->getMock();
+
+        $recordOperationMock
+            ->method('getData')
+            ->willReturn($localRecordData);
+
+        $event = new AfterRecordOperationEvent($recordOperationMock);
+
+        $subjectMock = $this
+            ->getMockBuilder(ForeignRelationSortingEventHandler::class)
+            ->onlyMethods(['getMmFieldConfigurations', 'orderOnForeignSideOfRelation', 'persistData'])
+            ->getMock();
+
+        $subjectMock
+            ->method('getMmFieldConfigurations')
+            ->willReturn($mmFieldConfiguration);
+
+        $subjectMock
+            ->method('orderOnForeignSideOfRelation')
+            ->willReturnOnConsecutiveCalls(... $foreignSideOrderReturns);
+
+        $subjectMock
+            ->expects(self::once())
+            ->method('persistData')
+            ->with($persistDataArgument);
+
+        $subjectMock->__invoke($event);
+    }
+
+    /**
+     * @return array
+     */
+    public function invokingGeneratesCorrectSortingDataDataProvider(): array
+    {
+        return [
+            'Single group' => [
+                [
+                    'fieldName' => [99],
+                ],
+                [
+                    'fieldName' => [
+                        'type' => 'group',
+                        'allowed' => 'foreignTableName',
+                    ],
+                ],
+                [
+                    [
+                        'foreignTableName' => [
+                            '99' => [
+                                'fieldName' => [1, 2, 3, 4, 5],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'foreignTableName' => [
+                        '99' => [
+                            'fieldName' => [1, 2, 3, 4, 5],
+                        ],
+                    ],
+                ],
+            ],
+            'Double group' => [
+                [
+                    'fieldName' => [98, 99],
+                ],
+                [
+                    'fieldName' => [
+                        'type' => 'group',
+                        'allowed' => 'foreignTableName',
+                    ],
+                ],
+                [
+                    [
+                        'foreignTableName' => [
+                            '98' => [
+                                'fieldName' => [1, 2, 3, 4, 5],
+                            ],
+                        ],
+                    ],
+                    [
+                        'foreignTableName' => [
+                            '99' => [
+                                'fieldName' => [6, 7, 8],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'foreignTableName' => [
+                        '98' => [
+                            'fieldName' => [1, 2, 3, 4, 5],
+                        ],
+                        '99' => [
+                            'fieldName' => [6, 7, 8],
+                        ],
+                    ],
+                ],
+            ],
+            'Single inline' => [
+                [
+                    'fieldName' => [99],
+                ],
+                [
+                    'fieldName' => [
+                        'type' => 'inline',
+                        'foreign_table' => 'foreignTableName',
+                    ],
+                ],
+                [
+                    [
+                        'foreignTableName' => [
+                            '99' => [
+                                'fieldName' => [1, 2, 3, 4, 5],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'foreignTableName' => [
+                        '99' => [
+                            'fieldName' => [1, 2, 3, 4, 5],
+                        ],
+                    ],
+                ],
+            ],
+            'Double inline' => [
+                [
+                    'fieldName' => [98, 99],
+                ],
+                [
+                    'fieldName' => [
+                        'type' => 'inline',
+                        'foreign_table' => 'foreignTableName',
+                    ],
+                ],
+                [
+                    [
+                        'foreignTableName' => [
+                            '98' => [
+                                'fieldName' => [1, 2, 3, 4, 5],
+                            ],
+                        ],
+                    ],
+                    [
+                        'foreignTableName' => [
+                            '99' => [
+                                'fieldName' => [6, 7, 8],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'foreignTableName' => [
+                        '98' => [
+                            'fieldName' => [1, 2, 3, 4, 5],
+                        ],
+                        '99' => [
+                            'fieldName' => [6, 7, 8],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/Tests/Unit/DataHandling/Operation/Event/Handler/ForeignRelationSortingEventHandlerTest.php
+++ b/Tests/Unit/DataHandling/Operation/Event/Handler/ForeignRelationSortingEventHandlerTest.php
@@ -8,6 +8,7 @@ use Pixelant\Interest\DataHandling\Operation\Event\AfterRecordOperationEvent;
 use Pixelant\Interest\DataHandling\Operation\Event\Handler\ForeignRelationSortingEventHandler;
 use Pixelant\Interest\DataHandling\Operation\UpdateRecordOperation;
 use Pixelant\Interest\Domain\Repository\RemoteIdMappingRepository;
+use Pixelant\Interest\Utility\CompatibilityUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -34,11 +35,19 @@ class ForeignRelationSortingEventHandlerTest extends UnitTestCase
 
         GeneralUtility::setSingletonInstance(RemoteIdMappingRepository::class, $mappingRepositoryMock);
 
-        $recordOperationMock = $this
-            ->getMockBuilder(UpdateRecordOperation::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['setData', 'getData'])
-            ->getMock();
+        if (CompatibilityUtility::typo3VersionIsLessThan('10')) {
+            $recordOperationMock = $this
+                ->getMockBuilder(UpdateRecordOperation::class)
+                ->disableOriginalConstructor()
+                ->setMethods(['setData', 'getData'])
+                ->getMock();
+        } else {
+            $recordOperationMock = $this
+                ->getMockBuilder(UpdateRecordOperation::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['setData', 'getData'])
+                ->getMock();
+        }
 
         $recordOperationMock
             ->method('getData')
@@ -46,10 +55,17 @@ class ForeignRelationSortingEventHandlerTest extends UnitTestCase
 
         $event = new AfterRecordOperationEvent($recordOperationMock);
 
-        $subjectMock = $this
-            ->getMockBuilder(ForeignRelationSortingEventHandler::class)
-            ->onlyMethods(['getMmFieldConfigurations', 'orderOnForeignSideOfRelation', 'persistData'])
-            ->getMock();
+        if (CompatibilityUtility::typo3VersionIsLessThan('10')) {
+            $subjectMock = $this
+                ->getMockBuilder(ForeignRelationSortingEventHandler::class)
+                ->setMethods(['getMmFieldConfigurations', 'orderOnForeignSideOfRelation', 'persistData'])
+                ->getMock();
+        } else {
+            $subjectMock = $this
+                ->getMockBuilder(ForeignRelationSortingEventHandler::class)
+                ->onlyMethods(['getMmFieldConfigurations', 'orderOnForeignSideOfRelation', 'persistData'])
+                ->getMock();
+        }
 
         $subjectMock
             ->method('getMmFieldConfigurations')


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description

* Sorted relation information was merged using array_merge_recursive(), which doesn't allow us to keep the keys that represent a record UID. Therefore, relations might have disappeared or sorting might not have worked. This was fixed by using TYPO3's ArrayUtility::mergeRecursiveWithOverrule().
* Repository classes now implement SingletonInterface and are therefore singletons in TYPO3's eyes.
* Cleanup of ForeignRelationSortingEventHandler.
* Basic unit test for ForeignRelationSortingEventHandler.