### PR TITLE
[BUGFIX] Always catch StopRecordOperationException

### DIFF
--- a/Classes/Command/CreateCommandController.php
+++ b/Classes/Command/CreateCommandController.php
@@ -64,14 +64,20 @@ class CreateCommandController extends AbstractReceiveCommandController
                     throw $exception;
                 }
 
-                (new UpdateRecordOperation(
-                    $data,
-                    $input->getArgument('endpoint'),
-                    $remoteId,
-                    $input->getArgument('language'),
-                    $input->getArgument('workspace'),
-                    $input->getOption('metaData')
-                ))();
+                try {
+                    (new UpdateRecordOperation(
+                        $data,
+                        $input->getArgument('endpoint'),
+                        $remoteId,
+                        $input->getArgument('language'),
+                        $input->getArgument('workspace'),
+                        $input->getOption('metaData')
+                    ))();
+                } catch (StopRecordOperationException $exception) {
+                    $output->writeln($exception->getMessage(), OutputInterface::VERBOSITY_VERY_VERBOSE);
+
+                    continue;
+                }
             } catch (\Throwable $exception) {
                 $exceptions[] = $exception;
             }

--- a/Classes/Command/UpdateCommandController.php
+++ b/Classes/Command/UpdateCommandController.php
@@ -64,14 +64,20 @@ class UpdateCommandController extends AbstractReceiveCommandController
                     throw $exception;
                 }
 
-                (new CreateRecordOperation(
-                    $data,
-                    $input->getArgument('endpoint'),
-                    $remoteId,
-                    $input->getArgument('language'),
-                    $input->getArgument('workspace'),
-                    $input->getOption('metaData')
-                ))();
+                try {
+                    (new CreateRecordOperation(
+                        $data,
+                        $input->getArgument('endpoint'),
+                        $remoteId,
+                        $input->getArgument('language'),
+                        $input->getArgument('workspace'),
+                        $input->getOption('metaData')
+                    ))();
+                } catch (StopRecordOperationException $exception) {
+                    $output->writeln($exception->getMessage(), OutputInterface::VERBOSITY_VERY_VERBOSE);
+
+                    continue;
+                }
             } catch (\Throwable $exception) {
                 $exceptions[] = $exception;
             }

--- a/Classes/RequestHandler/AbstractRecordRequestHandler.php
+++ b/Classes/RequestHandler/AbstractRecordRequestHandler.php
@@ -6,6 +6,7 @@ namespace Pixelant\Interest\RequestHandler;
 
 use Pixelant\Interest\Context;
 use Pixelant\Interest\Database\RelationHandlerWithoutReferenceIndex;
+use Pixelant\Interest\DataHandling\Operation\Event\Exception\StopRecordOperationException;
 use Pixelant\Interest\DataHandling\Operation\Exception\AbstractException;
 use Pixelant\Interest\RequestHandler\ExceptionConverter\OperationToRequestHandlerExceptionConverter;
 use Psr\Http\Message\ResponseInterface;
@@ -335,6 +336,8 @@ abstract class AbstractRecordRequestHandler extends AbstractRequestHandler
 
                         try {
                             $this->handleSingleOperation($table, $remoteId, $language, $workspace, $data);
+                        } catch (StopRecordOperationException $exception) {
+                            continue;
                         } catch (AbstractException $exception) {
                             $exceptions[$table][$remoteId][$language][$workspace] = $exception;
                         }


### PR DESCRIPTION
When calling `interest:create --update` on a remote ID that exists or `interest:update --create` on a remote ID that doesn't exist, `StopRecordOperationException` will now be caught as it should.

`StopRecordOperationException` is always caught in REST requests and will not be reported as an exception in the response. 

Resolves: #67