### PR TITLE
[BUGFIX] Return PID as zero only when rootLevel is 1

### DIFF
--- a/Classes/DataHandling/Operation/AbstractRecordOperation.php
+++ b/Classes/DataHandling/Operation/AbstractRecordOperation.php
@@ -291,7 +291,7 @@ abstract class AbstractRecordOperation
      */
     private function resolveStoragePid(): int
     {
-        if ($GLOBALS['TCA'][$this->getTable()]['ctrl']['rootLevel'] ?? null === 1) {
+        if (($GLOBALS['TCA'][$this->getTable()]['ctrl']['rootLevel'] ?? null) === 1) {
             return 0;
         }
 


### PR DESCRIPTION
A condition was missing a bracket, which led to the condition being interpreted with wrong precedence, resulting in PID being set to zero at the wrong time.