### PR TITLE
[FEATURE] HttpResponseEvent for post-processing responses

### DIFF
--- a/Classes/Middleware/Event/HttpResponseEvent.php
+++ b/Classes/Middleware/Event/HttpResponseEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pixelant\Interest\Middleware\Event;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * An event created at the very end of the interest request, right before control is passed back to TYPO3.
+ */
+class HttpResponseEvent
+{
+    protected ResponseInterface $response;
+
+    public function __construct(ResponseInterface $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return ResponseInterface
+     */
+    public function getResponse(): ResponseInterface
+    {
+        return $this->response;
+    }
+
+    /**
+     * @param ResponseInterface $response
+     */
+    public function setResponse(ResponseInterface $response)
+    {
+        $this->response = $response;
+    }
+}

--- a/Classes/Middleware/Event/HttpResponseEventHandlerInterface.php
+++ b/Classes/Middleware/Event/HttpResponseEventHandlerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pixelant\Interest\Middleware\Event;
+
+interface HttpResponseEventHandlerInterface
+{
+    /**
+     * Handle an HttpResponseEvent.
+     *
+     * @param HttpResponseEvent $event
+     */
+    public function __invoke(HttpResponseEvent $event): void;
+}

--- a/Classes/RequestHandler/AbstractRecordRequestHandler.php
+++ b/Classes/RequestHandler/AbstractRecordRequestHandler.php
@@ -67,13 +67,13 @@ abstract class AbstractRecordRequestHandler extends AbstractRequestHandler
         $decodedContent = json_decode($body) ?? [];
 
         if (is_string($decodedContent->metaData ?? null)) {
-            $decodedContent->metaData = json_decode($body) ?? [];
+            $decodedContent->metaData = json_decode($decodedContent->metaData) ?? [];
         }
 
         $this->metaData = $this->convertObjectToArrayRecursive((array)($decodedContent->metaData ?? []));
 
         if (is_string($decodedContent->data ?? null)) {
-            $decodedContent->data = json_decode($body) ?? new \stdClass();
+            $decodedContent->data = json_decode($decodedContent->data) ?? new \stdClass();
         }
 
         $data = $decodedContent->data ?? new \stdClass();

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -14,7 +14,7 @@ if (\Pixelant\Interest\Utility\CompatibilityUtility::typo3VersionIsLessThan('10.
 return [
     'frontend' => [
         'interest-rest-requests' => [
-            'target' => Pixelant\Interest\Middlewares\RequestMiddleware::class,
+            'target' => Pixelant\Interest\Middleware\RequestMiddleware::class,
             'before' => $before,
             'after' => $after,
         ],


### PR DESCRIPTION
Introduces `HttpResponseEvent` which can be used to modify or process the response before it is sent to TYPO3. The event constructor takes one argument, a `ResponseInterface`-compatible object.

Also fixes the implementation of data or metaData as JSON string. If data or metaData is a string, we try to decode it as JSON. In some cases it can be easier to supply JSON within JSON rather than just supplying one big JSON array.