### PR TITLE
[TASK] Move responsibility to correct class

### DIFF
--- a/Classes/DataHandling/Operation/CreateRecordOperation.php
+++ b/Classes/DataHandling/Operation/CreateRecordOperation.php
@@ -30,14 +30,19 @@ class CreateRecordOperation extends AbstractRecordOperation
 
         parent::__construct($recordRepresentation, $metaData);
 
-        if (!isset($this->getData()['pid'])) {
-            $this->setData(array_merge($this->getData(), ['pid' => $this->getStoragePid()]));
+        if (!isset($this->getDataForDataHandler()['pid'])) {
+            $this->setDataForDataHandler(
+                array_merge(
+                    $this->getDataForDataHandler(),
+                    ['pid' => $this->getStoragePid()]
+                )
+            );
         }
 
         $uid = $this->getUid() ?: StringUtility::getUniqueId('NEW');
         $table = $recordRepresentation->getRecordInstanceIdentifier()->getTable();
 
-        $this->dataHandler->datamap[$table][$uid] = $this->getData();
+        $this->dataHandler->datamap[$table][$uid] = $this->getDataForDataHandler();
 
         $this->resolvePendingRelations($uid);
     }

--- a/Classes/DataHandling/Operation/DeleteRecordOperation.php
+++ b/Classes/DataHandling/Operation/DeleteRecordOperation.php
@@ -26,7 +26,7 @@ class DeleteRecordOperation extends AbstractRecordOperation
     public function __construct(
         RecordRepresentation $recordRepresentation
     ) {
-        $this->workspace = $recordRepresentation->getRecordInstanceIdentifier()->getWorkspace();
+        $this->recordRepresentation = $recordRepresentation;
 
         $this->mappingRepository = GeneralUtility::makeInstance(RemoteIdMappingRepository::class);
 
@@ -38,15 +38,10 @@ class DeleteRecordOperation extends AbstractRecordOperation
             );
         }
 
-        $this->remoteId = $remoteId;
         $this->metaData = [];
-        $this->data = [];
-        $this->table = $recordRepresentation->getRecordInstanceIdentifier()->getTable();
+        $this->dataForDataHandler = [];
 
         $this->pendingRelationsRepository = GeneralUtility::makeInstance(PendingRelationsRepository::class);
-
-        $this->language = $recordRepresentation->getRecordInstanceIdentifier()->getLanguage();
-        $this->uid = $this->resolveUid();
 
         $this->hash = md5(static::class . serialize($this->getArguments()));
 

--- a/Classes/DataHandling/Operation/Event/Handler/DeferSysFileReferenceRecordOperationEventHandler.php
+++ b/Classes/DataHandling/Operation/Event/Handler/DeferSysFileReferenceRecordOperationEventHandler.php
@@ -13,9 +13,9 @@ class DeferSysFileReferenceRecordOperationEventHandler extends AbstractDetermine
     {
         if (
             $this->getEvent()->getRecordOperation()->getTable() === 'sys_file_reference'
-            && isset($this->getEvent()->getRecordOperation()->getData()['uid_local'])
+            && isset($this->getEvent()->getRecordOperation()->getDataForDataHandler()['uid_local'])
         ) {
-            return $this->getEvent()->getRecordOperation()->getData()['uid_local'];
+            return $this->getEvent()->getRecordOperation()->getDataForDataHandler()['uid_local'];
         }
 
         return null;

--- a/Classes/DataHandling/Operation/Event/Handler/ForeignRelationSortingEventHandler.php
+++ b/Classes/DataHandling/Operation/Event/Handler/ForeignRelationSortingEventHandler.php
@@ -61,7 +61,7 @@ class ForeignRelationSortingEventHandler implements AfterRecordOperationEventHan
         $persistedRecordData = DatabaseUtility::getRecord(
             $recordOperation->getTable(),
             $recordOperation->getUid()
-        ) ?? $recordOperation->getData();
+        ) ?? $recordOperation->getDataForDataHandler();
 
         $fieldConfigurations = [];
         foreach (array_keys($GLOBALS['TCA'][$recordOperation->getTable()]['columns']) as $fieldName) {
@@ -186,7 +186,7 @@ class ForeignRelationSortingEventHandler implements AfterRecordOperationEventHan
         $data = [];
 
         foreach ($this->getMmFieldConfigurations() as $fieldName => $fieldConfiguration) {
-            $relationIds = $this->event->getRecordOperation()->getData()[$fieldName] ?? [];
+            $relationIds = $this->event->getRecordOperation()->getDataForDataHandler()[$fieldName] ?? [];
 
             if (empty($relationIds)) {
                 continue;

--- a/Classes/DataHandling/Operation/Event/Handler/PersistFileDataEventHandler.php
+++ b/Classes/DataHandling/Operation/Event/Handler/PersistFileDataEventHandler.php
@@ -59,7 +59,7 @@ class PersistFileDataEventHandler implements BeforeRecordOperationEventHandlerIn
             return;
         }
 
-        $data = $this->event->getRecordOperation()->getData();
+        $data = $this->event->getRecordOperation()->getDataForDataHandler();
 
         $fileBaseName = $data['name'] ?? '';
 
@@ -128,7 +128,7 @@ class PersistFileDataEventHandler implements BeforeRecordOperationEventHandlerIn
 
         $this->event->getRecordOperation()->setUid($file->getUid());
 
-        $this->event->getRecordOperation()->setData($data);
+        $this->event->getRecordOperation()->setDataForDataHandler($data);
     }
 
     /**
@@ -295,7 +295,7 @@ class PersistFileDataEventHandler implements BeforeRecordOperationEventHandlerIn
 
         if ($hashedSubfolders > 0) {
             if ($fileBaseName === '') {
-                $fileNameHash = bin2hex(random_bytes(18));
+                $fileNameHash = bin2hex(random_bytes($hashedSubfolders));
             } else {
                 $fileNameHash = md5($fileBaseName);
             }
@@ -312,6 +312,7 @@ class PersistFileDataEventHandler implements BeforeRecordOperationEventHandlerIn
                 $downloadFolder = $downloadFolder->createFolder($subfolderName);
             }
         }
+
         return $downloadFolder;
     }
 

--- a/Classes/DataHandling/Operation/Event/Handler/RelationSortingAsMetaDataEventHandler.php
+++ b/Classes/DataHandling/Operation/Event/Handler/RelationSortingAsMetaDataEventHandler.php
@@ -58,7 +58,7 @@ class RelationSortingAsMetaDataEventHandler implements BeforeRecordOperationEven
             $fieldConfiguration = TcaUtility::getTcaFieldConfigurationAndRespectColumnsOverrides(
                 $recordOperation->getTable(),
                 $fieldName,
-                $recordOperation->getData(),
+                $recordOperation->getDataForDataHandler(),
                 $recordOperation->getRemoteId()
             );
 
@@ -84,7 +84,7 @@ class RelationSortingAsMetaDataEventHandler implements BeforeRecordOperationEven
 
         $sortingIntents = [];
         foreach ($fieldConfigurations as $fieldName => $configuration) {
-            $sortingIntent = $recordOperation->getData()[$fieldName] ?? [];
+            $sortingIntent = $recordOperation->getDataForDataHandler()[$fieldName] ?? [];
 
             if (empty($sortingIntent)) {
                 continue;

--- a/Classes/DataHandling/Operation/UpdateRecordOperation.php
+++ b/Classes/DataHandling/Operation/UpdateRecordOperation.php
@@ -30,6 +30,6 @@ class UpdateRecordOperation extends AbstractRecordOperation
 
         $table = $recordRepresentation->getRecordInstanceIdentifier()->getTable();
 
-        $this->dataHandler->datamap[$table][$this->getUid()] = $this->getData();
+        $this->dataHandler->datamap[$table][$this->getUid()] = $this->getDataForDataHandler();
     }
 }

--- a/Classes/Domain/Model/Dto/RecordInstanceIdentifier.php
+++ b/Classes/Domain/Model/Dto/RecordInstanceIdentifier.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Pixelant\Interest\Domain\Model\Dto;
 
+use Pixelant\Interest\DataHandling\Operation\Exception\ConflictException;
 use Pixelant\Interest\Domain\Model\Dto\Exception\InvalidArgumentException;
+use Pixelant\Interest\Domain\Repository\RemoteIdMappingRepository;
 use Pixelant\Interest\Utility\TcaUtility;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Site\SiteFinder;
@@ -40,6 +42,11 @@ class RecordInstanceIdentifier
      * @var string|null
      */
     protected ?string $workspace;
+
+    /**
+     * @var int|null
+     */
+    protected ?int $uid = null;
 
     /**
      * @param string $table
@@ -113,6 +120,26 @@ class RecordInstanceIdentifier
     public function hasWorkspace(): bool
     {
         return $this->workspace !== null;
+    }
+
+    /**
+     * @return int
+     */
+    public function getUid(): int
+    {
+        if ($this->uid === null) {
+            $this->uid = $this->resolveUid();
+        }
+
+        return $this->uid;
+    }
+
+    /**
+     * @param int $uid
+     */
+    public function setUid(int $uid)
+    {
+        $this->uid = $uid;
     }
 
     /**
@@ -210,6 +237,30 @@ class RecordInstanceIdentifier
         throw new InvalidArgumentException(
             'The language "' . $language . '" is not defined in this TYPO3 instance.'
         );
+    }
+
+    /**
+     * Resolves the UID for the remote ID.
+     *
+     * @return int
+     * @throws ConflictException
+     */
+    protected function resolveUid(): int
+    {
+        $mappingRepository = GeneralUtility::makeInstance(RemoteIdMappingRepository::class);
+
+        if (
+            $mappingRepository->exists($this->getRemoteIdWithAspects())
+            && $mappingRepository->table($this->getRemoteIdWithAspects()) !== $this->getTable()
+        ) {
+            throw new ConflictException(
+                'The remote ID "' . $this->getRemoteIdWithAspects() . '" exists, '
+                . 'but doesn\'t belong to the table "' . $this->getRemoteIdWithAspects() . '".',
+                1634213051764
+            );
+        }
+
+        return $mappingRepository->get($this->getRemoteIdWithAspects());
     }
 
     /**

--- a/Classes/Domain/Model/Dto/RecordInstanceIdentifier.php
+++ b/Classes/Domain/Model/Dto/RecordInstanceIdentifier.php
@@ -211,4 +211,12 @@ class RecordInstanceIdentifier
             'The language "' . $language . '" is not defined in this TYPO3 instance.'
         );
     }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->getRemoteIdWithAspects();
+    }
 }

--- a/Documentation/Implementing/Extending/Index.rst
+++ b/Documentation/Implementing/Extending/Index.rst
@@ -13,6 +13,11 @@ If you need additional functionality or the extisting functionality of the exten
 PSR-14 Events
 =============
 
+.. _extending-events-list:
+
+Events
+------
+
 The events are listed in order of execution.
 
 .. php:namespace:: Pixelant\Interest\Router\Event
@@ -89,9 +94,34 @@ The events are listed in order of execution.
 
       :param Psr\Http\Message\ResponseInterface $response:
 
+.. _extending-events-typo3v9
+
+In TYPO3 version 9
+------------------
+
+TYPO3 version 9 doesn't support PSR-14 events, but it's using signals and slots instead. Luckily, PSR-14 Events and EventHandlers can be made to work with them as well. You can register an EventHandler as a SignalSlot using this convenience function:
+
+.. code-block:: php
+
+   \Pixelant\Interest\Utility\CompatibilityUtility::registerEventHandlerAsSignalSlot(
+       string $eventClassName,
+       string $eventHandlerClassName
+   );
+
+It will map the class and methods correctly. The only difference is that you can't change the order of execution, as the slots are called in the order they are registered.
+
+Here's how the function is used by the Interest extension itself:
+
+.. code-block:: php
+
+   \Pixelant\Interest\Utility\CompatibilityUtility::registerEventHandlerAsSignalSlot(
+       \Pixelant\Interest\DataHandling\Operation\Event\BeforeRecordOperationEvent::class,
+       \Pixelant\Interest\DataHandling\Operation\Event\Handler\StopIfRepeatingPreviousRecordOperation::class
+   );
+
 .. _extending-how-works:
 
-How it works
-============
+PHP API
+=======
 
 

--- a/Documentation/Implementing/Extending/Index.rst
+++ b/Documentation/Implementing/Extending/Index.rst
@@ -138,7 +138,7 @@ The extension keeps track of the mapping between remote IDs and TYPO3 records in
 .. _extending-touch:
 
 Touching and the touched
-------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 When a record is created or updated, the `touched` timestamp is updated. The timestamp is also updated if the remote request *intended* to update the record, but the Interest extension decided not to do it, for example because there was nothing to change. In this way, the time a record was last touched may more recent than the record's modification date.
 
@@ -147,7 +147,7 @@ The time the record was last touched can help you verify that a request was proc
 .. _extending-touch-methods:
 
 Relevant methods
-~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^
 
 .. php:namespace:: Pixelant\Interest\Domain\Repository
 
@@ -190,13 +190,16 @@ Relevant methods
 .. _extending-touch-example:
 
 Example
-~~~~~~~
+^^^^^^^
 
 Fetching all remote IDs that have not been touched since the same time yesterday.
 
 .. code-block:: php
 
+   use Pixelant\Interest\Domain\Model\Dto\RecordInstanceIdentifier;
+   use Pixelant\Interest\Domain\Model\Dto\RecordRepresentation;
    use Pixelant\Interest\Domain\Repository\RemoteIdMappingRepository;
+   use Pixelant\Interest\DataHandling\Operation\DeleteRecordOperation;
    use TYPO3\CMS\Core\Utility\GeneralUtility;
 
    $mappingRepository = GeneralUtility::makeInstance(RemoteIdMappingRepository::class);
@@ -209,4 +212,61 @@ Fetching all remote IDs that have not been touched since the same time yesterday
            );
        ))();
    }
+
+.. _extending-mapping-metadata:
+
+Metadata
+~~~~~~~~
+
+The mapping table also contains a field that can contain serialized meta information about the record. Any class can add and retrieve meta information from this field.
+
+Here's two existing use cases:
+
+* **Foreign relation sorting order** by :php:`\Pixelant\Interest\DataHandling\Operation\Event\Handler\ForeignRelationSortingEventHandler`
+* **File modification info** by :php:`\Pixelant\Interest\DataHandling\Operation\Event\Handler\PersistFileDataEventHandler`
+
+.. warning::
+
+   Make sure that you don't mix up the metadata in the mapping table with the metadata that is sent to operations, e.g. using the `metaData` property or the `--metaData` option. These are not related.
+
+.. note::
+
+   The field data is encoded as JSON. Any objects must be serialized so they can be stored as a string.
+
+.. _extending-mapping-metadata-methods:
+
+Relevant methods
+^^^^^^^^^^^^^^^^
+
+.. php:namespace:: Pixelant\Interest\Domain\Repository
+
+.. php:class:: RemoteIdMappingRepository
+
+   .. php:method:: getMetaData($remoteId)
+
+      Retrieves all of the metadata entries as a key-value array.
+
+      :param string $remoteId: The remote ID of the record to return the metadata for.
+
+      :returntype: array
+
+   .. php:method:: getMetaDataValue($remoteId, $key)
+
+      Retrieves a metadata entry.
+
+      :param string $remoteId: The remote ID of the record to return the metadata for.
+
+      :param string $key: The originator class's fully qualified class name.
+
+      :returntype: string, float, int, array, or null
+
+   .. php:method:: getMetaDataValue($remoteId, $key, $value)
+
+      Sets a metadata entry.
+
+      :param string $remoteId: The remote ID of the record to return the metadata for.
+
+      :param string $key: The originator class's fully qualified class name.
+
+      :param string|float|int|array|null $value: The value to set.
 

--- a/Documentation/Implementing/Extending/Index.rst
+++ b/Documentation/Implementing/Extending/Index.rst
@@ -144,6 +144,11 @@ When a record is created or updated, the `touched` timestamp is updated. The tim
 
 The time the record was last touched can help you verify that a request was processed — or to find the remote IDs that were not mentioned at all. In the latter case, knowing remote IDs that are no longer updated regularly can tell you which remote IDs should be deleted.
 
+.. _extending-touch-methods:
+
+Relevant methods
+~~~~~~~~~~~~~~~~
+
 .. php:namespace:: Pixelant\Interest\Domain\Repository
 
 .. php:class:: RemoteIdMappingRepository
@@ -181,4 +186,27 @@ The time the record was last touched can help you verify that a request was proc
       :param bool $excludeManual: When true, remote IDs flagged as manual will be excluded from the result. Usually a good idea, as manual entries aren't usually a part of any update workflow.
 
       :returntype: bool
+
+.. _extending-touch-example:
+
+Example
+~~~~~~~
+
+Fetching all remote IDs that have not been touched since the same time yesterday.
+
+.. code-block:: php
+
+   use Pixelant\Interest\Domain\Repository\RemoteIdMappingRepository;
+   use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+   $mappingRepository = GeneralUtility::makeInstance(RemoteIdMappingRepository::class);
+
+   foreach($mappingRepository->findAllUntouchedSince(time() - 86400) as $remoteId) {
+       (new DeleteRecordOperation(
+           new RecordRepresentation(
+               [],
+               new RecordInstanceIdentifier($remoteId)
+           );
+       ))();
+   }
 

--- a/Documentation/Implementing/Extending/Index.rst
+++ b/Documentation/Implementing/Extending/Index.rst
@@ -124,6 +124,16 @@ Here's how the function is used by the Interest extension itself:
 How it works
 ============
 
+.. _extending-record-representation:
+
+Internal representation and identity
+------------------------------------
+
+Inside the extension, a record's state and identity is maintained by two data transfer object classes:
+
+* **A record's unique identity** from creation to deletion is represented by :php:`Pixelant\Interest\Domain\Model\Dto\RecordInstanceIdentifier`.
+* **A record's current state**, including the data that should be written to the database is represented by :php:`Pixelant\Interest\Domain\Model\Dto\RecordRepresentation`.
+
 .. _extending-mapping:
 
 Mapping table

--- a/Documentation/Implementing/Extending/Index.rst
+++ b/Documentation/Implementing/Extending/Index.rst
@@ -119,9 +119,66 @@ Here's how the function is used by the Interest extension itself:
        \Pixelant\Interest\DataHandling\Operation\Event\Handler\StopIfRepeatingPreviousRecordOperation::class
    );
 
-.. _extending-how-works:
+.. _extending-how-it-works:
 
-PHP API
-=======
+How it works
+============
 
+.. _extending-mapping:
+
+Mapping table
+-------------
+
+The extension keeps track of the mapping between remote IDs and TYPO3 records in the table `tx_interest_remote_id_mapping`. In addition to mapping information, the table contains metadata about each record.
+
+.. warning::
+
+   You should never access the `tx_interest_remote_id_mapping` table directly, but use the classes and methods described here.
+
+.. _extending-touch:
+
+Touching and the touched
+------------------------
+
+When a record is created or updated, the `touched` timestamp is updated. The timestamp is also updated if the remote request *intended* to update the record, but the Interest extension decided not to do it, for example because there was nothing to change. In this way, the time a record was last touched may more recent than the record's modification date.
+
+The time the record was last touched can help you verify that a request was processed — or to find the remote IDs that were not mentioned at all. In the latter case, knowing remote IDs that are no longer updated regularly can tell you which remote IDs should be deleted.
+
+.. php:namespace:: Pixelant\Interest\Domain\Repository
+
+.. php:class:: RemoteIdMappingRepository
+
+   .. php:method:: touch($remoteId)
+
+      Touches the remote ID and nothing else. Sets the `touched` timestamp for the remote ID to the current time.
+
+      :param string $remoteId: The remote ID of the record to touch.
+
+   .. php:method:: touched($remoteId)
+
+      Returns the touched timestamp for the record.
+
+      :param string $remoteId: The remote ID of the record to touch.
+
+      :returntype: int
+
+   .. php:method:: findAllUntouchedSince($timestamp, $excludeManual = true)
+
+      Returns an array containing all remote IDs that have *not* been touched since :php:`$timestamp`.
+
+      :param int $timestamp: Unix timestamp.
+
+      :param bool $excludeManual: When true, remote IDs flagged as manual will be excluded from the result. Usually a good idea, as manual entries aren't usually a part of any update workflow.
+
+      :returntype: bool
+
+   .. php:method:: findAllTouchedSince($timestamp, $excludeManual = true)
+
+      Returns an array containing all remote IDs that have been touched since :php:`$timestamp`.
+
+      :param int $timestamp: Unix timestamp.
+
+      :param bool $excludeManual: When true, remote IDs flagged as manual will be excluded from the result. Usually a good idea, as manual entries aren't usually a part of any update workflow.
+
+      :returntype: bool
 

--- a/Documentation/Implementing/Extending/Index.rst
+++ b/Documentation/Implementing/Extending/Index.rst
@@ -134,6 +134,25 @@ Inside the extension, a record's state and identity is maintained by two data tr
 * **A record's unique identity** from creation to deletion is represented by :php:`Pixelant\Interest\Domain\Model\Dto\RecordInstanceIdentifier`.
 * **A record's current state**, including the data that should be written to the database is represented by :php:`Pixelant\Interest\Domain\Model\Dto\RecordRepresentation`.
 
+When creating a :php:`RecordRepresentation`, you must also supply a :php:`RecordInstanceIdentifier`:
+
+.. code-block::
+
+   use Pixelant\Interest\Domain\Model\Dto\RecordInstanceIdentifier;
+   use Pixelant\Interest\Domain\Model\Dto\RecordRepresentation;
+
+   new RecordRepresentation(
+       [
+           'title' => 'My record title',
+           'bodytext' => 'This is a story about ...',
+       ],
+       new RecordInstanceIdentifier(
+           'tt_content',
+           'ContentElementA',
+           'en'
+       )
+   );
+
 .. _extending-mapping:
 
 Mapping table
@@ -218,7 +237,7 @@ Fetching all remote IDs that have not been touched since the same time yesterday
        (new DeleteRecordOperation(
            new RecordRepresentation(
                [],
-               new RecordInstanceIdentifier($remoteId)
+               new RecordInstanceIdentifier('table', $remoteId)
            );
        ))();
    }

--- a/Documentation/Implementing/Extending/Index.rst
+++ b/Documentation/Implementing/Extending/Index.rst
@@ -153,6 +153,109 @@ When creating a :php:`RecordRepresentation`, you must also supply a :php:`Record
        )
    );
 
+.. _extending-record-operations:
+
+Record operations
+-----------------
+
+Record operations are the core of the Interest extension. Each represents one operation requested from the outside. One record operation is not the same as one database operation. Some record operations will not be executed (if it is a duplicate of the previous operation on the same remote ID) or deferred (if the record operation requires a condition to be fulfilled before it can be executed).
+
+The record operations are invokable, and are executed as such:
+
+.. code-block: php
+
+   (CreateRecordOperation(/* ... */))();
+
+.. _extending-record-operation-types:
+
+Record operation types
+~~~~~~~~~~~~~~~~~~~~~~
+
+There are three record operations:
+
+* Create
+* Update
+* Delete
+
+All are subclasses of :php:`Pixelant\Interest\DataHandling\Operation\AbstractRecordOperation`, and both Create and Update share its API, while Delete has a reduced constructor.
+
+.. info::
+
+   The constructor of :php:`Pixelant\Interest\DataHandling\Operation\DeleteRecordOperation` **might change in the future**. A delete operation requires no field data. It is unnecessary (and only a requirement of the parent class) to require a :php:`Pixelant\Interest\Domain\Model\Dto\RecordRepresentation`. It should be sufficient to supply a :php:`Pixelant\Interest\Domain\Model\Dto\RecordInstanceIdentifier`.
+
+.. php:namespace:: Pixelant\Interest\DataHandling\Operation
+
+.. php:class:: AbstractRecordOperation
+
+..  php:currentnamespace:: Pixelant\Interest\DataHandling\Operation
+
+.. php:class:: CreateRecordOperation
+
+..  php:currentnamespace:: Pixelant\Interest\DataHandling\Operation
+
+.. php:class:: UpdateRecordOperation
+
+   .. php:method:: __construct($recordRepresentation, $metaData)
+
+      :param Pixelant\Interest\Domain\Model\Dto\RecordRepresentation $recordRepresentation:
+
+      :param array $metaData:
+
+   .. php:method:: getDataForDataHandler()
+
+      Get the data that will be written to the DataHandler. This is a modified version of the data in :php:`$this->getRecordRepresentation()->getData()`.
+
+      :returntype: array
+
+   .. php:method:: setDataForDataHandler($dataForDataHandler)
+
+      Set the data that will be written to the DataHandler.
+
+      :param array $dataForDataHandler:
+
+   .. php:method:: getRecordRepresentation()
+
+      :returntype: Pixelant\Interest\Domain\Model\Dto\RecordRepresentation
+
+   .. php:method:: getMetaData()
+
+      Returns the metadata array for the operation. This metadata is not used other than to generate the uniqueness hash for the operation. You can use it to transfer useful information, e.g. for transformations. See: :ref:`userts-accessing-metadata`
+
+      :returntype: array
+
+   .. php:method:: getContentRenderer()
+
+      Returns a special :php:`ContentObjectRenderer` for this operation. The data array is populated with operation-specific information when the operation object is initialized. It is not updated if this information changes.
+
+      .. code-block:: php
+
+         $contentObjectRenderer->data = [
+            'table' => $this->getTable(),
+            'remoteId' => $this->getRemoteId(),
+            'language' => $this->getLanguage()->getHreflang(),
+            'workspace' => null,
+            'metaData' => $this->getMetaData(),
+            'data' => $this->getDataForDataHandler(),
+        ];
+
+      :returntype: TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
+
+   .. php:method:: getHash()
+
+      Get the unique hash of this operation. The hash is generated when the operation object is initialized, and it is not changed. This hash makes it possible for the Interest extension to know whether the same operation has been run before.
+
+      :returntype: string
+
+..  php:currentnamespace:: Pixelant\Interest\DataHandling\Operation
+
+.. php:class:: DeleteRecordOperation
+
+   .. php:method:: __construct($recordRepresentation)
+
+      You cannot send metadata information to a delete operation.
+
+      :param Pixelant\Interest\Domain\Model\Dto\RecordRepresentation $recordRepresentation:
+
 .. _extending-mapping:
 
 Mapping table

--- a/Documentation/Implementing/Extending/Index.rst
+++ b/Documentation/Implementing/Extending/Index.rst
@@ -1,0 +1,40 @@
+.. include:: ../../Includes.txt
+
+.. _extending:
+
+======================
+Changing and Extending
+======================
+
+If you need additional functionality or the extisting functionality of the extension isn't quite what you need, this section tells you how to change the behavior of the Interest extesnsion. It also tells you how to extend the functionality, as well as a bit about the extension's inner workings.
+
+.. _extending-events:
+
+PSR-14 Events
+=============
+
+The events are listed in order of execution.
+
+.. _extending-beforerecordoperationevent:
+
+`BeforeRecordOperationEvent`
+----------------------------
+
+..  php:namespace::  Pixelant\Interest\DataHandling\Operation\Event
+
+..  php:class:: BeforeRecordOperationEvent
+
+    Datetime class
+
+EventHandler Interface:
+   :php:`\Pixelant\Interest\DataHandling\Operation\Event\BeforeRecordOperationEventHandlerInterface`
+
+Executed when:
+   When a :php:`*RecordOperation` object has been initialized, but before data validations. (Actually inside the :php:`AbstractRecordOperation::__construct()`.)
+
+.. _extending-how-works:
+
+How it works
+============
+
+

--- a/Documentation/Implementing/Extending/Index.rst
+++ b/Documentation/Implementing/Extending/Index.rst
@@ -15,22 +15,79 @@ PSR-14 Events
 
 The events are listed in order of execution.
 
-.. _extending-beforerecordoperationevent:
+.. php:namespace:: Pixelant\Interest\Router\Event
 
-`BeforeRecordOperationEvent`
-----------------------------
+.. php:class:: HttpRequestRouterHandleByEvent
 
-..  php:namespace::  Pixelant\Interest\DataHandling\Operation\Event
+   Called in :php:`HttpRequestRouter::handleByMethod()`. Can be used to modify the request and entry point parts before they are passed on to a RequestHandler.
 
-..  php:class:: BeforeRecordOperationEvent
+   EventHandlers for this event should implement :php:`Pixelant\Interest\Router\Event\HttpRequestRouterHandleByEventHandlerInterface`.
 
-    Datetime class
+   .. php:method:: getEntryPointParts()
 
-EventHandler Interface:
-   :php:`\Pixelant\Interest\DataHandling\Operation\Event\BeforeRecordOperationEventHandlerInterface`
+      Returns an array of the entry point parts, i.e. the parts of the URL used to detect the correct entry point. Given the URL `http://www.example.com/rest/tt_content/ContentRemoteId` and the default entry point `rest`, the entry point parts will be :php:`['tt_content', 'ContentRemoteId']`.
 
-Executed when:
-   When a :php:`*RecordOperation` object has been initialized, but before data validations. (Actually inside the :php:`AbstractRecordOperation::__construct()`.)
+      :returntype: array
+
+   .. php:method:: setEntryPointParts($entryPointParts)
+
+      :param array $entryPointParts:
+
+   .. php:method:: getRequest()
+
+      :returntype: Psr\Http\Message\ServerRequestInterface
+
+   .. php:method:: setRequest($request)
+
+      :param Psr\Http\Message\ServerRequestInterface $request:
+
+.. php:namespace::  Pixelant\Interest\DataHandling\Operation\Event
+
+.. php:class:: BeforeRecordOperationEvent
+
+   Called inside the :php:`AbstractRecordOperation::__construct()` when a :php:`*RecordOperation` object has been initialized, but before data validations.
+
+   EventHandlers for this event should implement :php:`Pixelant\Interest\DataHandling\Operation\Event\BeforeRecordOperationEventHandlerInterface`.
+
+   EventHandlers for this event can throw these exceptions:
+
+   :php:`Pixelant\Interest\DataHandling\Operation\Event\Exception\StopRecordOperationException`
+      To quietly stop the record operation. This exception is only logged as informational and the operation will be treated as successful. E.g. used when deferring an operation.
+
+   :php:`Pixelant\Interest\DataHandling\Operation\Event\Exception\BeforeRecordOperationEventException`
+      Will stop the record operation and log as an error. The operation will be treated as unsuccessful.
+
+   .. php:method:: getRecordOperation()
+
+      :returntype: Pixelant\Interest\DataHandling\Operation\AbstractRecordOperation
+
+.. php:namespace::  Pixelant\Interest\DataHandling\Operation\Event
+
+.. php:class:: AfterRecordOperationEvent
+
+   Called as the last thing inside the :php:`AbstractRecordOperation::__invoke()` method, after all data persistence and pending relations have been resolved.
+
+   EventHandlers for this event should implement :php:`Pixelant\Interest\DataHandling\Operation\Event\AfterRecordOperationEventHandlerInterface`.
+
+   .. php:method:: getRecordOperation()
+
+      :returntype: Pixelant\Interest\DataHandling\Operation\AbstractRecordOperation
+
+.. php:namespace::  Pixelant\Interest\Middleware\Event
+
+.. php:class:: HttpResponseEvent
+
+   Called in the middleware, just before control is handled back over to TYPO3 during an HTTP request. Allows modification of the response object.
+
+   EventHandlers for this event should implement :php:`Pixelant\Interest\Middleware\Event\HttpResponseEventHandlerInterface`.
+
+   .. php:method:: getResponse()
+
+      :returntype: Psr\Http\Message\ResponseInterface
+
+   .. php:method:: setResponse($response)
+
+      :param Psr\Http\Message\ResponseInterface $response:
 
 .. _extending-how-works:
 

--- a/Documentation/Implementing/FileHandling/Index.rst
+++ b/Documentation/Implementing/FileHandling/Index.rst
@@ -1,0 +1,104 @@
+.. include:: ../../Includes.txt
+
+.. _implementing-files:
+
+=============
+File Handling
+=============
+
+.. note::
+
+   File handling is managed in the EventHandler class :php:`\Pixelant\Interest\DataHandling\Operation\Event\Handler\PersistFileDataEventHandler`.
+
+.. _implementing-files-data-source:
+
+File Data Sources
+=================
+
+When writing to the `sys_file` table, the extension introduces two virtual fields:
+
+* **fileData:** Base64-encoded file data.
+* **url:** A publicly accessible URL. The file data will be downloaded from this location or handled by an `OnlineMediaHelper <https://docs.typo3.org/typo3cms/extensions/core/Changelog/7.5/Feature-61799-ImprovedHandlingOfOnlineMedia.html>`__ (such as for YouTube and Vimeo URLs, that are turned into `.youtube` and `.vimeo` files).
+
+.. note::
+
+   File uploads are also affected by the :ref:`Handle Existing Files <extension-conf-properties-behavior>` behavior setting in the Extension Configuration.
+
+.. _implementing-files-data-source-filedata:
+
+Base64-encoded file data
+------------------------
+
+With the extension's default configuration, this example will create the file at :file:`fileadmin/tx_interest/image.png`.
+
+..  code-block:: json
+
+   {
+     "sys_file": {
+       "ExampleRemoteId": {
+         "fileData": "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8...",
+         "name": "image.png"
+       }
+     }
+   }
+
+The `name` field must be supplied and include a file extension.
+
+.. _implementing-files-data-source-url:
+
+Publicly accessible URL
+-----------------------
+
+.. note::
+
+   When used repeatedly on the same remote ID, the extension will look for `If-Modified-Since` and `If-None-Match` (`ETag`) response headers to determine if a file has changed remotely or not. If it has not changed, the file will not be downloaded again. This means it is possible to always supply the URL, but e.g. only rename the file, if that is the only change in the data.
+
+.. _implementing-files-data-source-url-normal:
+
+Normal URL
+^^^^^^^^^^
+
+The default behavior is that the file specified in the `url` field is downloaded to the download location specified in the :ref:`persistence.fileUploadFolderPath` UserTS configuration parameter.
+
+With the extension's default configuration, this example will download the file at `https://example.com/image.png` to :file:`fileadmin/tx_interest/image.png`.
+
+..  code-block:: json
+
+   {
+     "sys_file": {
+       "ExampleRemoteId": {
+         "url": "https://example.com/image.png",
+         "name": "image.png"
+       }
+     }
+   }
+
+The `name` field must be supplied and include a file extension.
+
+.. _implementing-files-data-source-url-mediahelper:
+
+URL with OnlineMediaHelper
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If an `OnlineMediaHelper <https://docs.typo3.org/typo3cms/extensions/core/Changelog/7.5/Feature-61799-ImprovedHandlingOfOnlineMedia.html>`__ is registered for the URL, it will take priority over any other file handling.
+
+With the extension's default configuration, this example will create the file :file:`fileadmin/tx_interest/TYPO3_-_Channel_Intro.youtube`.
+
+..  code-block:: json
+
+   {
+     "sys_file": {
+       "ExampleRemoteId": {
+         "url": "https://youtu.be/zpOVYePk6mM",
+       }
+     }
+   }
+
+If the `name` field is used, the file will use the name supplied there and the correct extension added if necessary (e.g. `.youtube`).
+
+.. _implementing-files-data-source-naming:
+
+File name sanitation
+====================
+
+File names are santized using TYPO3's standard sanitation methods, so expect spaces to be replaced with underscores, etc.

--- a/Documentation/Implementing/Index.rst
+++ b/Documentation/Implementing/Index.rst
@@ -13,6 +13,7 @@ Implementing
 
    Cli/Index
    Rest/Index
+   FileHandling/Index
 
 .. _choosing-rest-or-cli:
 

--- a/Documentation/Implementing/Index.rst
+++ b/Documentation/Implementing/Index.rst
@@ -14,6 +14,7 @@ Implementing
    Cli/Index
    Rest/Index
    FileHandling/Index
+   Extending/Index
 
 .. _choosing-rest-or-cli:
 

--- a/Tests/Functional/DataHandling/Operation/UpdateRecordOperationTest.php
+++ b/Tests/Functional/DataHandling/Operation/UpdateRecordOperationTest.php
@@ -84,7 +84,7 @@ class UpdateRecordOperationTest extends AbstractRecordOperationFunctionalTestCas
             )
             ->fetchAssociative();
 
-        self::assertEquals($createdRecord, $expectedRow, 'Comparing created record with expected data.');
+        self::assertEquals($expectedRow, $createdRecord, 'Comparing created record with expected data.');
     }
 
     public function recordRepresentationAndCorrespondingRowDataProvider()

--- a/Tests/Unit/DataHandling/Operation/CreateRecordOperationTest.php
+++ b/Tests/Unit/DataHandling/Operation/CreateRecordOperationTest.php
@@ -74,6 +74,6 @@ class CreateRecordOperationTest extends UnitTestCase
             )
         );
 
-        self::assertEquals(0, $subject->getData()['pid']);
+        self::assertEquals(0, $subject->getDataForDataHandler()['pid']);
     }
 }

--- a/Tests/Unit/DataHandling/Operation/Event/Handler/ForeignRelationSortingEventHandlerTest.php
+++ b/Tests/Unit/DataHandling/Operation/Event/Handler/ForeignRelationSortingEventHandlerTest.php
@@ -39,18 +39,18 @@ class ForeignRelationSortingEventHandlerTest extends UnitTestCase
             $recordOperationMock = $this
                 ->getMockBuilder(UpdateRecordOperation::class)
                 ->disableOriginalConstructor()
-                ->setMethods(['setData', 'getData'])
+                ->setMethods(['setDataForDataHandler', 'getDataForDataHandler'])
                 ->getMock();
         } else {
             $recordOperationMock = $this
                 ->getMockBuilder(UpdateRecordOperation::class)
                 ->disableOriginalConstructor()
-                ->onlyMethods(['setData', 'getData'])
+                ->onlyMethods(['setDataForDataHandler', 'getDataForDataHandler'])
                 ->getMock();
         }
 
         $recordOperationMock
-            ->method('getData')
+            ->method('getDataForDataHandler')
             ->willReturn($localRecordData);
 
         $event = new AfterRecordOperationEvent($recordOperationMock);


### PR DESCRIPTION
Identity-related methods in AbstractRecordOperation has been taken over by RecordInstanceIdentifier.

Also adds documentation for file handling and events.