### PR TITLE
[BUGFIX] Allow empty request body on DELETE

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -16,7 +16,7 @@ hooks:
   post-start:
   - exec: composer install --no-progress
   - exec: export PHP_IDE_CONFIG="serverName=interest.ddev.site"
-omit_containers: [dba, ddev-ssh-agent]
+omit_containers: [ddev-ssh-agent]
 webimage_extra_packages: [parallel]
 use_dns_when_possible: true
 composer_version: "2.1.14"

--- a/Classes/RequestHandler/DeleteRequestHandler.php
+++ b/Classes/RequestHandler/DeleteRequestHandler.php
@@ -9,6 +9,8 @@ use Pixelant\Interest\Domain\Model\Dto\RecordRepresentation;
 
 class DeleteRequestHandler extends AbstractRecordRequestHandler
 {
+    protected const EXPECT_EMPTY_REQUEST = true;
+
     /**
      * @inheritDoc
      */

--- a/Tests/Unit/RequestHandler/CreateOrUpdateRequestHandlerTest.php
+++ b/Tests/Unit/RequestHandler/CreateOrUpdateRequestHandlerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pixelant\Interest\Tests\Unit\RequestHandler;
+
+use Pixelant\Interest\RequestHandler\CreateOrUpdateRequestHandler;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class CreateOrUpdateRequestHandlerTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function emptyRequestBodyWillFail()
+    {
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, '');
+        rewind($stream);
+
+        $request = new ServerRequest(
+            'http://www.example.com/rest',
+            'PATCH',
+            $stream
+        );
+
+        $deleteHandlerMock = $this->getMockBuilder(CreateOrUpdateRequestHandler::class)
+            ->setConstructorArgs([
+                [
+                    'table',
+                    'remoteId',
+                ],
+                $request,
+            ])
+            ->setMethodsExcept(['handle'])
+            ->getMock();
+
+        $response = $deleteHandlerMock->handle();
+
+        self::assertEquals(400, $response->getStatusCode());
+    }
+}

--- a/Tests/Unit/RequestHandler/CreateRequestHandlerTest.php
+++ b/Tests/Unit/RequestHandler/CreateRequestHandlerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pixelant\Interest\Tests\Unit\RequestHandler;
+
+use Pixelant\Interest\RequestHandler\CreateRequestHandler;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class CreateRequestHandlerTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function emptyRequestBodyWillFail()
+    {
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, '');
+        rewind($stream);
+
+        $request = new ServerRequest(
+            'http://www.example.com/rest',
+            'POST',
+            $stream
+        );
+
+        $deleteHandlerMock = $this->getMockBuilder(CreateRequestHandler::class)
+            ->setConstructorArgs([
+                [
+                    'table',
+                    'remoteId',
+                ],
+                $request,
+            ])
+            ->setMethodsExcept(['handle'])
+            ->getMock();
+
+        $response = $deleteHandlerMock->handle();
+
+        self::assertEquals(400, $response->getStatusCode());
+    }
+}

--- a/Tests/Unit/RequestHandler/DeleteRequestHandlerTest.php
+++ b/Tests/Unit/RequestHandler/DeleteRequestHandlerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pixelant\Interest\Tests\Unit\RequestHandler;
+
+use Pixelant\Interest\RequestHandler\DeleteRequestHandler;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class DeleteRequestHandlerTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function emptyRequestBodyIsNoProblem()
+    {
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, '');
+        rewind($stream);
+
+        $request = new ServerRequest(
+            'http://www.example.com/rest',
+            'DELETE',
+            $stream
+        );
+
+        $deleteHandlerMock = $this->getMockBuilder(DeleteRequestHandler::class)
+            ->setConstructorArgs([
+                [
+                    'table',
+                    'remoteId',
+                ],
+                $request,
+            ])
+            ->setMethodsExcept(['handle'])
+            ->getMock();
+
+        $response = $deleteHandlerMock->handle();
+
+        self::assertEquals(200, $response->getStatusCode());
+    }
+}

--- a/Tests/Unit/RequestHandler/UpdateRequestHandlerTest.php
+++ b/Tests/Unit/RequestHandler/UpdateRequestHandlerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pixelant\Interest\Tests\Unit\RequestHandler;
+
+use Pixelant\Interest\RequestHandler\UpdateRequestHandler;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class UpdateRequestHandlerTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function emptyRequestBodyWillFail()
+    {
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, '');
+        rewind($stream);
+
+        $request = new ServerRequest(
+            'http://www.example.com/rest',
+            'PUT',
+            $stream
+        );
+
+        $deleteHandlerMock = $this->getMockBuilder(UpdateRequestHandler::class)
+            ->setConstructorArgs([
+                [
+                    'table',
+                    'remoteId',
+                ],
+                $request,
+            ])
+            ->setMethodsExcept(['handle'])
+            ->getMock();
+
+        $response = $deleteHandlerMock->handle();
+
+        self::assertEquals(400, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
Delete operations don't need a request body, but the extension was simply quitting early without giving any error message. 

HTTP DELETE requests with an empty request body will now be executed correctly. All other requests will return a 400 error.

Fixes #97