### PR TITLE
[BUGFIX] Delete remote ID only with parent record

### DIFF
--- a/Classes/DataHandling/Operation/DeleteRecordOperation.php
+++ b/Classes/DataHandling/Operation/DeleteRecordOperation.php
@@ -58,11 +58,4 @@ class DeleteRecordOperation extends AbstractRecordOperation
 
         $this->dataHandler->cmdmap[$this->getTable()][$this->getUid()]['delete'] = 1;
     }
-
-    public function __invoke()
-    {
-        parent::__invoke();
-
-        $this->mappingRepository->remove($this->getRemoteId());
-    }
 }

--- a/Classes/Hook/ProcessCmdmap.php
+++ b/Classes/Hook/ProcessCmdmap.php
@@ -33,7 +33,7 @@ class ProcessCmdmap
         $pasteUpdate,
         $pasteDatamap
     ) {
-        if ($command === 'delete') {
+        if ($command === 'delete' && $dataHandler->hasDeletedRecord($table, $id)) {
             /** @var RemoteIdMappingRepository $mappingRepository */
             $mappingRepository = GeneralUtility::makeInstance(RemoteIdMappingRepository::class);
 

--- a/Tests/Unit/Hook/ProcessCmdmapTest.php
+++ b/Tests/Unit/Hook/ProcessCmdmapTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pixelant\Interest\Tests\Unit\Hook;
+
+use Pixelant\Interest\DataHandling\DataHandler;
+use Pixelant\Interest\Domain\Repository\RemoteIdMappingRepository;
+use Pixelant\Interest\Hook\ProcessCmdmap;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ProcessCmdmapTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function deletesRemoteIdIfOwnerRecordHasBeenDeleted()
+    {
+        $this->resetSingletonInstances = true;
+
+        $dataHandlerMock = $this->createMock(DataHandler::class);
+
+        $dataHandlerMock
+            ->expects(self::exactly(1))
+            ->method('hasDeletedRecord')
+            ->with('table', 1)
+            ->willReturn(true);
+
+        $mappingRepositoryMock = $this->createMock(RemoteIdMappingRepository::class);
+
+        $mappingRepositoryMock
+            ->expects(self::exactly(1))
+            ->method('remove')
+            ->with('RemoteId');
+
+        $mappingRepositoryMock
+            ->expects(self::exactly(1))
+            ->method('getRemoteId')
+            ->with('table', 1)
+            ->willReturn('RemoteId');
+
+        GeneralUtility::setSingletonInstance(RemoteIdMappingRepository::class, $mappingRepositoryMock);
+
+        $subject = new ProcessCmdmap();
+
+        $subject->processCmdmap_postProcess(
+            'delete',
+            'table',
+            1,
+            null,
+            $dataHandlerMock,
+            null,
+            null
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function keepsRemoteIdIfOwnerRecordHasNotBeenDeleted()
+    {
+        $this->resetSingletonInstances = true;
+
+        $dataHandlerMock = $this->createMock(DataHandler::class);
+
+        $dataHandlerMock
+            ->expects(self::exactly(1))
+            ->method('hasDeletedRecord')
+            ->with('table', 1)
+            ->willReturn(false);
+
+        $mappingRepositoryMock = $this->createMock(RemoteIdMappingRepository::class);
+
+        $mappingRepositoryMock
+            ->expects(self::never())
+            ->method('remove');
+
+        $mappingRepositoryMock
+            ->expects(self::never())
+            ->method('getRemoteId')
+            ->with('table', 1);
+
+        GeneralUtility::setSingletonInstance(RemoteIdMappingRepository::class, $mappingRepositoryMock);
+
+        $subject = new ProcessCmdmap();
+
+        $subject->processCmdmap_postProcess(
+            'delete',
+            'table',
+            1,
+            null,
+            $dataHandlerMock,
+            null,
+            null
+        );
+    }
+}


### PR DESCRIPTION
When trying to delete a record, but the operation is unsuccessful, e.g. due to a permissions issue or another DataHandler error, the remote ID will no longer be deleted.

Fixes #99