### PR TITLE
[BUGFIX] Compatibility with changes in TYPO3 11.5.35, 12.4.10, and 12.4.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,27 +156,27 @@ jobs:
           - typo3-version: ^12.4
             php-version: 8.1
             composer-dependencies: highest
-            additional-requirements: "typo3/cms-reactions:\"^12.4\""
+            additional-requirements: "typo3/cms-reactions"
           - typo3-version: ^12.4
             php-version: 8.1
             composer-dependencies: lowest
-            additional-requirements: "typo3/cms-reactions:\"^12.4\""
+            additional-requirements: "typo3/cms-reactions"
           - typo3-version: ^12.4
             php-version: 8.2
             composer-dependencies: highest
-            additional-requirements: "typo3/cms-reactions:\"^12.4\""
+            additional-requirements: "typo3/cms-reactions"
           - typo3-version: ^12.4
             php-version: 8.2
             composer-dependencies: lowest
-            additional-requirements: "typo3/cms-reactions:\"^12.4\""
+            additional-requirements: "typo3/cms-reactions"
           - typo3-version: ^12.4
             php-version: 8.3
             composer-dependencies: highest
-            additional-requirements: "typo3/cms-reactions:\"^12.4\""
+            additional-requirements: "typo3/cms-reactions"
           - typo3-version: ^12.4
             php-version: 8.3
             composer-dependencies: lowest
-            additional-requirements: "typo3/cms-reactions:\"^12.4\""
+            additional-requirements: "typo3/cms-reactions"
   functional-tests:
     name: "Functional tests"
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,27 +156,27 @@ jobs:
           - typo3-version: ^12.4
             php-version: 8.1
             composer-dependencies: highest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:\"^12.4\""
           - typo3-version: ^12.4
             php-version: 8.1
             composer-dependencies: lowest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:\"^12.4\""
           - typo3-version: ^12.4
             php-version: 8.2
             composer-dependencies: highest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:\"^12.4\""
           - typo3-version: ^12.4
             php-version: 8.2
             composer-dependencies: lowest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:\"^12.4\""
           - typo3-version: ^12.4
             php-version: 8.3
             composer-dependencies: highest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:\"^12.4\""
           - typo3-version: ^12.4
             php-version: 8.3
             composer-dependencies: lowest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:\"^12.4\""
   functional-tests:
     name: "Functional tests"
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2.2.22
+          tools: composer:v2.2
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
@@ -188,7 +188,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2.2.22
+          tools: composer:v2.2
           extensions: mysqli
           coverage: none
       - name: "Show Composer version"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2.2
+          tools: composer:v2.2.22
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
@@ -188,7 +188,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2.2
+          tools: composer:v2.2.22
           extensions: mysqli
           coverage: none
       - name: "Show Composer version"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,27 +156,27 @@ jobs:
           - typo3-version: ^12.4
             php-version: 8.1
             composer-dependencies: highest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:^12.4"
           - typo3-version: ^12.4
             php-version: 8.1
             composer-dependencies: lowest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:^12.4"
           - typo3-version: ^12.4
             php-version: 8.2
             composer-dependencies: highest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:^12.4"
           - typo3-version: ^12.4
             php-version: 8.2
             composer-dependencies: lowest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:^12.4"
           - typo3-version: ^12.4
             php-version: 8.3
             composer-dependencies: highest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:^12.4"
           - typo3-version: ^12.4
             php-version: 8.3
             composer-dependencies: lowest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:^12.4"
   functional-tests:
     name: "Functional tests"
     runs-on: ubuntu-20.04
@@ -209,12 +209,12 @@ jobs:
       - name: "Install lowest dependencies with composer"
         if: "matrix.composer-dependencies == 'lowest'"
         run: |
-          composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
+          composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest typo3/minimal:"$TYPO3" $ADDITIONAL_REQUIREMENTS
           composer show
       - name: "Install highest dependencies with composer"
         if: "matrix.composer-dependencies == 'highest'"
         run: |
-          composer update --no-ansi --no-interaction --no-progress --with-dependencies
+          composer update --no-ansi --no-interaction --no-progress --with-dependencies typo3/minimal:"$TYPO3" $ADDITIONAL_REQUIREMENTS
           composer show
       - name: "Start MySQL"
         run: "sudo /etc/init.d/mysql start"
@@ -262,24 +262,24 @@ jobs:
           - typo3-version: ^12.4
             php-version: 8.1
             composer-dependencies: highest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:^12.4"
           - typo3-version: ^12.4
             php-version: 8.1
             composer-dependencies: lowest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:^12.4"
           - typo3-version: ^12.4
             php-version: 8.2
             composer-dependencies: highest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:^12.4"
           - typo3-version: ^12.4
             php-version: 8.2
             composer-dependencies: lowest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:^12.4"
           - typo3-version: ^12.4
             php-version: 8.3
             composer-dependencies: highest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:^12.4"
           - typo3-version: ^12.4
             php-version: 8.3
             composer-dependencies: lowest
-            additional-requirements: "typo3/cms-reactions"
+            additional-requirements: "typo3/cms-reactions:^12.4"

--- a/Classes/DataHandling/Operation/Event/Handler/RelationSortingAsMetaData.php
+++ b/Classes/DataHandling/Operation/Event/Handler/RelationSortingAsMetaData.php
@@ -92,7 +92,7 @@ class RelationSortingAsMetaData implements RecordOperationEventHandlerInterface
         foreach ($fieldConfigurations as $fieldName => $configuration) {
             $sortingIntent = $recordOperation->getDataForDataHandler()[$fieldName] ?? [];
 
-            if (($sortingIntent ?? []) === []) {
+            if ($sortingIntent === []) {
                 continue;
             }
 

--- a/Classes/DataHandling/Operation/Event/Handler/SetPid.php
+++ b/Classes/DataHandling/Operation/Event/Handler/SetPid.php
@@ -21,6 +21,7 @@ class SetPid implements RecordOperationEventHandlerInterface
         if (
             !$event->getRecordOperation()->isDataFieldSet('pid')
             && $event->getRecordOperation() instanceof CreateRecordOperation
+            && $event->getRecordOperation()->getTable() !== 'sys_file'
         ) {
             $event->getRecordOperation()->setDataFieldForDataHandler(
                 'pid',

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
 		"ext-json": "*",
 		"ext-pdo": "*",
-		"symfony/console": "^6.4",
+		"symfony/console": "^5.4 || ^6.0",
 		"symfony/polyfill-php81": "^1.28",
 		"typo3/cms-core": "^11.5.8 || ^12.4.6",
 		"typo3/cms-fluid": "^11.5.8 || ^12.4.6",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
 		"php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
 		"ext-json": "*",
 		"ext-pdo": "*",
+		"symfony/console": "^6.4",
 		"symfony/polyfill-php81": "^1.28",
 		"typo3/cms-core": "^11.5.8 || ^12.4.6",
 		"typo3/cms-fluid": "^11.5.8 || ^12.4.6",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -4,7 +4,7 @@
 $EM_CONF['interest'] = [
     'title' => 'Integration REST API',
     'description' => 'REST and CLI API for adding, updating, and deleting records in TYPO3. Tracks relations so records can be inserted in any order. Uses remote ID mapping so you don\'t have to keep track of what UID a record has gotten after import. Data is inserted using backend APIs as if a real human did it, so you can can inspect the record history and undo actions.',
-    'version' => '2.1.0',
+    'version' => '2.1.1',
     'state' => 'stable',
     'category' => 'plugin',
     'constraints' => [


### PR DESCRIPTION
* Prevents the use of symfony/console v7, introduced in TYPO3 v12.4.10.
* PID will no longer be set for operations on the `sys_file` table. Modifying this table through DataHandler was blocked in TYPO3 v11.5.35 and v12.4.11 due to a security issue. DataHandler will throw an error if `sys_file` fields are set, so this extension should not add any such fields to the data array.

Resolves #111 