### PR TITLE
[BUGFIX] Remove default value when using InputOption::VALUE_NONE

### DIFF
--- a/Classes/Command/AbstractRecordCommandController.php
+++ b/Classes/Command/AbstractRecordCommandController.php
@@ -42,15 +42,13 @@ abstract class AbstractRecordCommandController extends Command
                 'b',
                 InputOption::VALUE_NONE,
                 'If set, <remoteId> is ignored and <data> is an array where each key is a remote ID and each '
-                . 'value field data. Each set of remote ID and field data will be processed.',
-                false
+                . 'value field data. Each set of remote ID and field data will be processed.'
             )
             ->addOption(
                 'disableReferenceIndex',
                 null,
                 InputOption::VALUE_NONE,
-                'If set, the reference index will not be updated.',
-                false
+                'If set, the reference index will not be updated.'
             );
     }
 

--- a/Classes/Command/ClearRecordHashCommandController.php
+++ b/Classes/Command/ClearRecordHashCommandController.php
@@ -35,8 +35,7 @@ class ClearRecordHashCommandController extends Command
                 'contains',
                 'c',
                 InputOption::VALUE_NONE,
-                'The remoteId argument is a partial remote ID. Match all IDs containing the string.',
-                false
+                'The remoteId argument is a partial remote ID. Match all IDs containing the string.'
             );
     }
 

--- a/Classes/Command/CreateCommandController.php
+++ b/Classes/Command/CreateCommandController.php
@@ -32,8 +32,7 @@ class CreateCommandController extends AbstractReceiveCommandController
                 'update',
                 'u',
                 InputOption::VALUE_NONE,
-                'Quietly update the record if it already exists.',
-                false
+                'Quietly update the record if it already exists.'
             );
     }
 

--- a/Classes/Command/PendingRelationsCommandController.php
+++ b/Classes/Command/PendingRelationsCommandController.php
@@ -41,8 +41,7 @@ class PendingRelationsCommandController extends Command
                 'resolve',
                 'r',
                 InputOption::VALUE_NONE,
-                'Attempt to resolve pending relations where both sides exist.',
-                false
+                'Attempt to resolve pending relations where both sides exist.'
             );
     }
 

--- a/Classes/Command/UpdateCommandController.php
+++ b/Classes/Command/UpdateCommandController.php
@@ -32,8 +32,7 @@ class UpdateCommandController extends AbstractReceiveCommandController
                 'create',
                 'c',
                 InputOption::VALUE_NONE,
-                'Quietly create the record if it doesn\'t already exist.',
-                false
+                'Quietly create the record if it doesn\'t already exist.'
             );
     }
 


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->

This fix solves error "Cannot set a default value when using InputOption::VALUE_NONE mode."
