### PR TITLE
[TASK] Use Connection instead of PDO

### DIFF
--- a/Classes/Domain/Repository/DeferredRecordOperationRepository.php
+++ b/Classes/Domain/Repository/DeferredRecordOperationRepository.php
@@ -7,6 +7,7 @@ namespace Pixelant\Interest\Domain\Repository;
 use Doctrine\DBAL\Result;
 use Pixelant\Interest\DataHandling\Operation\AbstractRecordOperation;
 use Pixelant\Interest\Domain\Repository\Exception\InvalidQueryResultException;
+use TYPO3\CMS\Core\Database\Connection;
 
 class DeferredRecordOperationRepository extends AbstractRepository
 {
@@ -96,7 +97,7 @@ class DeferredRecordOperationRepository extends AbstractRepository
             ->where(
                 $queryBuilder->expr()->eq(
                     'uid',
-                    $queryBuilder->createNamedParameter($uid, \PDO::PARAM_INT)
+                    $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)
                 )
             )
             ->executeStatement();

--- a/Classes/Domain/Repository/PendingRelationsRepository.php
+++ b/Classes/Domain/Repository/PendingRelationsRepository.php
@@ -6,6 +6,7 @@ namespace Pixelant\Interest\Domain\Repository;
 
 use Doctrine\DBAL\Result;
 use Pixelant\Interest\Domain\Repository\Exception\InvalidQueryResultException;
+use TYPO3\CMS\Core\Database\Connection;
 
 /**
  * Database operations relating to pending relations to remote IDs that do not yet exist in the database.
@@ -31,7 +32,7 @@ class PendingRelationsRepository extends AbstractRepository
             ->where(
                 $queryBuilder->expr()->eq(
                     'remote_id',
-                    $queryBuilder->createNamedParameter($remoteId, \PDO::PARAM_STR)
+                    $queryBuilder->createNamedParameter($remoteId, Connection::PARAM_STR)
                 )
             )
             ->executeQuery();

--- a/Classes/Domain/Repository/RemoteIdMappingRepository.php
+++ b/Classes/Domain/Repository/RemoteIdMappingRepository.php
@@ -10,6 +10,7 @@ use Pixelant\Interest\DataHandling\Operation\Exception\IdentityConflictException
 use Pixelant\Interest\Domain\Repository\Exception\InvalidQueryResultException;
 use Pixelant\Interest\Utility\DatabaseUtility;
 use Pixelant\Interest\Utility\TcaUtility;
+use TYPO3\CMS\Core\Database\Connection;
 
 /**
  * Repository for interaction with the database table tx_interest_remote_id_mapping.
@@ -58,7 +59,7 @@ class RemoteIdMappingRepository extends AbstractRepository
             ->where(
                 $queryBuilder->expr()->eq(
                     'remote_id',
-                    $queryBuilder->createNamedParameter($remoteId, \PDO::PARAM_STR)
+                    $queryBuilder->createNamedParameter($remoteId, Connection::PARAM_STR)
                 )
             )
             ->executeQuery();
@@ -398,7 +399,7 @@ class RemoteIdMappingRepository extends AbstractRepository
             ->where(
                 $queryBuilder->expr()->eq(
                     'remote_id',
-                    $queryBuilder->createNamedParameter($remoteId, \PDO::PARAM_STR)
+                    $queryBuilder->createNamedParameter($remoteId, Connection::PARAM_STR)
                 )
             )
             ->executeQuery();


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [ ] [BUGFIX] - A bug fix
- [x] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->
In Doctrine DBAL v4, as described in the [documentation](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Database/QueryBuilder/Index.html#database-query-builder-create-named-parameter), support for using the `\PDO::PARAM_*` constants has been dropped in favor of the enum types. This should be migrated to `Connection::PARAM_*` in order to be compatible with TYPO3 v13 later on. `Connection::PARAM_*` can already be used now as it is compatible with TYPO3 11 and 12.